### PR TITLE
Add optional timeout (seconds) to cmd:Exec()

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -14,3 +14,16 @@ if err then error(err) end
 if not(result.status == 0) then error("status") end
 ```
 
+The default timeout is 10 seconds after which the command will be terminated. The default timeout may be overriden with an optional timeout value (seconds).
+
+```lua
+local cmd = require("cmd")
+local runtime = require("runtime")
+
+local command = "sleep 5"
+if runtime.goos() == "windows" then command = "timeout 1" end
+
+local result, err = cmd.exec(command, 1)
+if err then error(err) end
+if not(result.status == 0) then error("status") end
+```

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	// default execution timeout
-	Timeout = 10 * time.Second
+	// default execution timeout in seconds
+	Timeout = 10
 )
 
 // Exec(): lua cmd.exec(command) return ({status=0, stdout="", stderr=""}, err)
 func Exec(L *lua.LState) int {
 	command := L.CheckString(1)
+	timeout := time.Duration(L.OptInt64(2, Timeout)) * time.Second
 	var cmd *exec.Cmd
 
 	switch runtime.GOOS {
@@ -48,7 +49,7 @@ func Exec(L *lua.LState) int {
 	}()
 
 	select {
-	case <-time.After(Timeout):
+	case <-time.After(timeout):
 		go cmd.Process.Kill()
 		L.Push(lua.LNil)
 		L.Push(lua.LString(`execute timeout`))

--- a/cmd/test/test_api.lua
+++ b/cmd/test/test_api.lua
@@ -7,3 +7,14 @@ if runtime.goos() == "windows" then command = "timeout 1" end
 local result, err = cmd.exec(command)
 if err then error(err) end
 print(result.stdout)
+
+-- Test timeout
+local cmd = require("cmd")
+local runtime = require("runtime")
+
+local command = "sleep 5"
+if runtime.goos() == "windows" then command = "timeout 1" end
+
+local result, err = cmd.exec(command, 1)
+if err == nil then error("timeout expected but did not occur") end
+if err ~= "execute timeout" then error("expected 'execute timeout' but instead got '" .. err .. "'") end


### PR DESCRIPTION
The hardcoded const Timeout value of 10 seconds is not useful for all but trivial operations. This patch adds an optional int64 value to the exec() signature so that the timeout may optionally be set to a different value.

The default behavior has not been modified and is backwards API compatible.