### PR TITLE
http_client. add headers from response to result.

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -1,6 +1,25 @@
 # http [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/http?status.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/http)
 
-## Usage
+## Functions
+
+- `client()` - returns http client instance for further usage. Avaliable options as table:
+```
+proxy="http(s)://<user>:<password>@host:<port>",
+timeout= 10,
+insecure_ssl=false,
+user_agent = "gopher-lua",
+basic_auth_user = "",
+basic_auth_password = "",
+headers = {"key"="value"},
+debug = false,
+```
+- `request(method, url, [data])` - make request userdata.
+
+## Methods
+### client
+- `do_request(request)` - returns result of request. Avaliable data are: 'body', 'headers', 'code'
+
+## Examples
 
 ### Client
 

--- a/http/test/test_client.lua
+++ b/http/test/test_client.lua
@@ -13,6 +13,7 @@ local req, err = http.request("GET", "http://127.0.0.1:1111/get")
 if err then error(err) end
 local resp, err = client_1:do_request(req)
 if err then error(err) end
+if not(resp.headers['Content-Length'] == "2") then error("resp headers") end
 if not(resp.code == 200) then error("resp code") end
 if not(resp.body == "OK") then error("resp body") end
 print("done: http.client:get")


### PR DESCRIPTION
Greetings. Add response headers to result table. It may be useful if server sends desired data via headers. Tokens, entity tags, etc
Also minor changes in readme for http_client.