### PR TITLE
Use the tests.RunLuaTestFile in a few more places including preload - where the "shellescape" was also added.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.15', '1.16', '1.17', '1.18']
 
     services: {}
     steps:

--- a/json/api_test.go
+++ b/json/api_test.go
@@ -1,17 +1,14 @@
 package json
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
 
 	inspect "github.com/vadv/gopher-lua-libs/inspect"
-	lua "github.com/yuin/gopher-lua"
 )
 
 func TestApi(t *testing.T) {
-	state := lua.NewState()
-	Preload(state)
-	inspect.Preload(state)
-	if err := state.DoFile("./test/test_api.lua"); err != nil {
-		t.Fatalf("execute test: %s\n", err.Error())
-	}
+	preload := tests.SeveralPreloadFuncs(Preload, inspect.Preload)
+	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "./test/test_api.lua"))
 }

--- a/json/test/test_api.lua
+++ b/json/test/test_api.lua
@@ -1,15 +1,22 @@
 local json = require("json")
 local inspect = require("inspect")
 
-local jsonStringWithNull = [[{"a":{"b":1, "c":null}}]]
-local jsonString = [[{"a":{"b":1}}]]
+function TestJson(t)
+    local jsonStringWithNull = [[{"a":{"b":1, "c":null}}]]
+    local jsonString = [[{"a":{"b":1}}]]
 
-local result, err = json.decode(jsonStringWithNull)
-if err then error(err) end
-if not(result["a"]["b"] == 1) then error("must be decode") end
-print("done: json.decode()")
+    local result, err = json.decode(jsonStringWithNull)
+    t:Run("decode", function(t)
+        if err then error(err) end
+        if result["a"]["b"] ~= 1 then error("must be decode") end
+        if result["a"]["c"] ~= nil then error("c is not nil") end
+        print("done: json.decode()")
+    end)
 
-local result, err = json.encode(result)
-if err then error(err) end
-if not(result==jsonString) then error("must be encode "..inspect(result)) end
-print("done: json.encode()")
+    local result, err = json.encode(result)
+    t:Run("encode omits null values", function(t)
+        if err then error(err) end
+        if result ~= jsonString then error("must be encode "..inspect(result)) end
+        print("done: json.encode()")
+    end)
+end

--- a/preload.lua
+++ b/preload.lua
@@ -1,30 +1,41 @@
-require("cert_util")
-require("db")
-require("filepath")
-require("inspect")
-require("ioutil")
-require("json")
-require("regexp")
-require("strings")
-require("tac")
-require("tcp")
-require("time")
-require("xmlpath")
-require("yaml")
-require("plugin")
-require("runtime")
-require("cmd")
-require("telegram")
-require("zabbix")
-require("storage")
-require("crypto")
-require("goos")
-require("humanize")
-require("chef")
-require("template")
-require("pprof")
-require("cloudwatch")
-require("log")
-require("prometheus")
-require("pb")
-require("stats")
+function TestRequireModule(t)
+    modules = {
+	    "shellescape",
+        "cert_util",
+        "chef",
+        "cloudwatch",
+        "cmd",
+        "crypto",
+        "db",
+        "filepath",
+        "goos",
+        "humanize",
+        "inspect",
+        "ioutil",
+        "json",
+        "log",
+        "pb",
+        "plugin",
+        "pprof",
+        "prometheus",
+        "regexp",
+        "runtime",
+        "stats",
+        "storage",
+        "strings",
+        "tac",
+        "tcp",
+        "telegram",
+        "template",
+        "time",
+        "xmlpath",
+        "yaml",
+        "zabbix",
+    }
+    for _, module in ipairs(modules) do
+        t:Run(module, function(t)
+            require(module)
+        end)
+    end
+end
+

--- a/preload.lua
+++ b/preload.lua
@@ -1,6 +1,5 @@
 function TestRequireModule(t)
     modules = {
-	    "shellescape",
         "cert_util",
         "chef",
         "cloudwatch",
@@ -20,6 +19,7 @@ function TestRequireModule(t)
         "prometheus",
         "regexp",
         "runtime",
+        "shellescape",
         "stats",
         "storage",
         "strings",

--- a/preload_test.go
+++ b/preload_test.go
@@ -1,15 +1,11 @@
 package libs
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
-
-	lua "github.com/yuin/gopher-lua"
 )
 
 func TestPreload(t *testing.T) {
-	state := lua.NewState()
-	Preload(state)
-	if err := state.DoFile("./preload.lua"); err != nil {
-		t.Fatalf("execute test: %s\n", err.Error())
-	}
+	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./preload.lua"))
 }

--- a/shellescape/api_test.go
+++ b/shellescape/api_test.go
@@ -1,16 +1,13 @@
 package shellescape
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/vadv/gopher-lua-libs/inspect"
 	"github.com/vadv/gopher-lua-libs/tests"
-	lua "github.com/yuin/gopher-lua"
 	"testing"
 )
 
 func TestApi(t *testing.T) {
-	preloadForTest := func(L *lua.LState) {
-		Preload(L)
-		inspect.Preload(L)
-	}
-	tests.RunLuaTestFile(t, preloadForTest, "test/test_api.lua")
+	preload := tests.SeveralPreloadFuncs(Preload, inspect.Preload)
+	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "test/test_api.lua"))
 }

--- a/strings/api_test.go
+++ b/strings/api_test.go
@@ -1,15 +1,11 @@
 package strings
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
-
-	lua "github.com/yuin/gopher-lua"
 )
 
 func TestApi(t *testing.T) {
-	state := lua.NewState()
-	Preload(state)
-	if err := state.DoFile("./test/test_api.lua"); err != nil {
-		t.Fatalf("execute test: %s\n", err.Error())
-	}
+	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./test/test_api.lua"))
 }

--- a/strings/test/test_api.lua
+++ b/strings/test/test_api.lua
@@ -2,25 +2,29 @@ local strings = require("strings")
 
 local str = "hello world"
 
-local t = strings.split(str, " ")
-local count_t = 0
-for k, v in pairs(t) do
-    count_t = count_t + 1
-    if k == 1 then if not(v == "hello") then error("strings.split()") end end
-    if k == 2 then if not(v == "world") then error("strings.split()") end end
+function TestSplit(t)
+    local str_parts = strings.split(str, " ")
+    assert(type(str_parts) == 'table')
+    assert(#str_parts == 2, string.format("%d ~= 2", #str_parts))
+    assert(str_parts[1] == "hello", string.format("%s ~= hello", str_parts[1]))
+    assert(str_parts[2] == "world", string.format("%s ~= world", str_parts[2]))
 end
-if not(count_t == 2) then error("string.split()") end
-print("done: strings.split()")
 
-if not(strings.has_prefix(str, "hello")) then error("strings.has_prefix()") end
-if not(strings.has_suffix(str, "world")) then error("strings.has_suffix()") end
-print("done: strings.has_suffix, strings.has_prefix")
+function TestHasPrefix(t)
+    assert(strings.has_prefix(str, "hello"), [[not strings.has_prefix("hello")]])
+end
 
-if not(strings.trim(str, "world") == "hello ") then error("strings.trim()") end
-if not(strings.trim(str, "hello ") == "world") then error("strings.trim()") end
-if not(strings.trim_prefix(str, "hello ") == "world") then error("strings.trim()") end
-if not(strings.trim_suffix(str, "hello ") == "hello world") then error("strings.trim()") end
-print("done: strings.trim()")
+function TestHasSuffix(t)
+    assert(strings.has_suffix(str, "world"), [[not strings.has_suffix("world")]])
+end
 
-if not(strings.contains(str, "hello ") == true) then error("strings.contains()") end
-print("done: strings.contains()")
+function TestTrim(t)
+    assert(strings.trim(str, "world") == "hello ", "strings.trim()")
+    assert(strings.trim(str, "hello ") == "world", "strings.trim()")
+    assert(strings.trim_prefix(str, "hello ") == "world", "strings.trim()")
+    assert(strings.trim_suffix(str, "hello ") == "hello world", "strings.trim()")
+end
+
+function TestContains(t)
+    assert(strings.contains(str, "hello ") == true, "strings.contains()")
+end

--- a/tests/assertions.go
+++ b/tests/assertions.go
@@ -1,0 +1,1 @@
+package tests

--- a/yaml/api_test.go
+++ b/yaml/api_test.go
@@ -1,40 +1,11 @@
 package yaml
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	lua "github.com/yuin/gopher-lua"
+	"github.com/vadv/gopher-lua-libs/tests"
+	"testing"
 )
 
 func TestApi(t *testing.T) {
-	// Setup the VM
-	L := lua.NewState()
-	defer L.Close()
-	Preload(L)
-
-	// Load the test cases from file
-	err := L.DoFile("./test/test_api.lua")
-	require.NoError(t, err)
-	test := L.CheckTable(1)
-	L.Pop(1)
-
-	// For each method on the returned test object, invoke it safely with PCall.
-	testCount := 0
-	test.ForEach(func(key lua.LValue, value lua.LValue) {
-		if value.Type() != lua.LTFunction {
-			return
-		}
-		testCount++
-		t.Run(lua.LVAsString(key), func(t *testing.T) {
-			L.Push(value)
-			L.Push(test)
-			require.NoError(t, L.PCall(1, 0, nil))
-		})
-	})
-
-	// Ensure we ran non-zero tests.
-	assert.NotEqual(t, 0, testCount, "test should not be empty")
+	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./test/test_api.lua"))
 }

--- a/yaml/test/test_api.lua
+++ b/yaml/test/test_api.lua
@@ -2,7 +2,7 @@ local yaml = require("yaml")
 local test = {}
 
 -- test decode
-function test:decode()
+function Test_decode(t)
     local text = [[
 a:
   b: 1
@@ -10,11 +10,11 @@ a:
     local result, err = yaml.decode(text)
     assert(not err, tostring(err))
     assert(result["a"]["b"] == 1, tostring(result["a"]["b"]))
-    print("done: yaml.decode()")
+    print("done: yaml.decode(t)n")
 end
 
 -- test decode with no args throws exception
-function test:decode_no_args()
+function Test_decode_no_args(t)
     local ok, errMsg = pcall(yaml.decode)
     assert(not ok)
     assert(errMsg)
@@ -22,7 +22,7 @@ function test:decode_no_args()
 end
 
 -- test encode of decoded(text) == text
-function test:decoded_text_equals_text()
+function Test_decoded_text_equals_text(t)
     local text = [[
 a:
   b: 1
@@ -35,7 +35,7 @@ a:
 end
 
 -- test encode(slice) works
-function test:encode_slice_works()
+function Test_encode_slice_works(t)
     local encodedSlice = yaml.encode({ "foo", "bar", "baz" })
     assert(encodedSlice == [[
 - foo
@@ -45,7 +45,7 @@ function test:encode_slice_works()
 end
 
 -- test encode(sparse slice) works
-function test:encode_sparse_slice_returns_map()
+function Test_encode_sparse_slice_returns_map(t)
     local slice = { [0] = "foo", [1] = "bar", [2] = "baz" }
     local encodedSlice = yaml.encode(slice)
     assert(encodedSlice == [[
@@ -56,7 +56,7 @@ function test:encode_sparse_slice_returns_map()
 end
 
 -- test encode(map) works
-function test:encode_map_returns_map()
+function Test_encode_map_returns_map(t)
     local map = { foo = "bar", bar = { 1, 2, 3.45 } }
     local encodedMap = yaml.encode(map)
     assert(encodedMap == [[
@@ -69,7 +69,7 @@ foo: bar
 end
 
 -- test encode(function) fails
-function test:encode_function_fails()
+function Test_encode_function_fails(t)
     local _, errMsg = yaml.encode(function()
         return ""
     end)
@@ -83,7 +83,7 @@ function test:encode_function_fails()
 end
 
 -- test cycles
-function test:cycles_return_error()
+function Test_cycles_return_error(t)
     local t1 = {}
     local t2 = { t1 = t1 }
     t1[t2] = t2

--- a/yaml/test/test_api.lua
+++ b/yaml/test/test_api.lua
@@ -1,5 +1,4 @@
 local yaml = require("yaml")
-local test = {}
 
 -- test decode
 function Test_decode(t)
@@ -92,4 +91,3 @@ function Test_cycles_return_error(t)
     assert(errMsg:find("nested table"), tostring(errMsg))
 end
 
-return test


### PR DESCRIPTION
Using this splits each group of assertions into a separate test case reported by the go test runner.