### PR TITLE
Added encoder and decoder for json and yaml, and strings.Reader and Buffer

### DIFF
--- a/io/README.md
+++ b/io/README.md
@@ -1,6 +1,11 @@
 # Wrappers for golang io
 
+*NOTE*: These aren't exposed to LUA directly, but used as utilities for other classes, which need 
+the bridge between lua file and these interfaces: 
+
 - io.Reader
 - io.Writer
 - io.Seeker
 - io.Closer
+
+See usages of `CheckIOReader` and `CheckIOWriter` in json and yaml modules.

--- a/io/README.md
+++ b/io/README.md
@@ -1,0 +1,6 @@
+# Wrappers for golang io
+
+- io.Reader
+- io.Writer
+- io.Seeker
+- io.Closer

--- a/io/wrappers.go
+++ b/io/wrappers.go
@@ -1,0 +1,108 @@
+package io
+
+import (
+	"errors"
+	"fmt"
+	lua "github.com/yuin/gopher-lua"
+	"io"
+)
+
+type luaIOWrapper struct {
+	ls  *lua.LState
+	obj lua.LValue
+
+	readMethod  *lua.LFunction
+	writeMethod *lua.LFunction
+	seekMethod  *lua.LFunction
+	closeMethod *lua.LFunction
+}
+
+//NewLuaIOWrapper creates a new luaIOWrapper atop the lua io object
+func NewLuaIOWrapper(L *lua.LState, io lua.LValue) *luaIOWrapper {
+	ret := &luaIOWrapper{
+		ls:  L,
+		obj: io,
+	}
+	ret.readMethod, _ = L.GetField(io, "read").(*lua.LFunction)
+	ret.writeMethod, _ = L.GetField(io, "write").(*lua.LFunction)
+	ret.seekMethod, _ = L.GetField(io, "seek").(*lua.LFunction)
+	ret.closeMethod, _ = L.GetField(io, "close").(*lua.LFunction)
+	return ret
+}
+
+func (l *luaIOWrapper) Read(p []byte) (n int, err error) {
+	if l.readMethod == nil {
+		return 0, errors.New("object does not have read method")
+	}
+	n = len(p)
+
+	L := l.ls
+	L.Push(l.readMethod)
+	L.Push(l.obj)
+	L.Push(lua.LNumber(n))
+	if err = L.PCall(2, 1, nil); err != nil {
+		n = 0
+		return
+	}
+	result := L.Get(1)
+	L.Pop(L.GetTop())
+	if result.Type() == lua.LTNil {
+		return 0, io.EOF
+	}
+	readString := lua.LVAsString(result)
+	copy(p, readString)
+	n = len(readString)
+	return
+}
+
+func (l *luaIOWrapper) Write(p []byte) (n int, err error) {
+	if l.writeMethod == nil {
+		return 0, errors.New("object does not have write method")
+	}
+	n = len(p)
+	L := l.ls
+	L.Push(l.writeMethod)
+	L.Push(l.obj)
+	L.Push(lua.LString(p))
+	err = L.PCall(2, 0, nil)
+	return
+}
+
+func (l *luaIOWrapper) Seek(offset int64, whence int) (int64, error) {
+	if l.seekMethod == nil {
+		return 0, errors.New("object does not have seek method")
+	}
+	var luaWhence string
+	switch whence {
+	case io.SeekStart:
+		luaWhence = "set"
+	case io.SeekEnd:
+		luaWhence = "end"
+	case io.SeekCurrent:
+		luaWhence = "cur"
+	default:
+		return 0, fmt.Errorf("unknown whence: %d", whence)
+	}
+
+	L := l.ls
+	L.Push(l.seekMethod)
+	L.Push(l.obj)
+	L.Push(lua.LString(luaWhence))
+	L.Push(lua.LNumber(offset))
+	if err := L.PCall(3, 1, nil); err != nil {
+		return 0, err
+	}
+	ret := L.CheckNumber(1)
+	L.Pop(L.GetTop())
+	return int64(ret), nil
+}
+
+func (l *luaIOWrapper) Close() error {
+	if l.closeMethod == nil {
+		return errors.New("object does not have close method")
+	}
+	L := l.ls
+	L.Push(l.closeMethod)
+	L.Push(l.obj)
+	return L.PCall(1, 0, nil)
+}

--- a/io/wrappers.go
+++ b/io/wrappers.go
@@ -30,7 +30,7 @@ func NewLuaIOWrapper(L *lua.LState, io lua.LValue) *luaIOWrapper {
 	return ret
 }
 
-func CheckWriter(L *lua.LState, n int) io.Writer {
+func CheckIOWriter(L *lua.LState, n int) io.Writer {
 	any := L.CheckAny(n)
 	if ud, ok := any.(*lua.LUserData); ok {
 		if writer, ok := ud.Value.(io.Writer); ok {
@@ -45,7 +45,7 @@ func CheckWriter(L *lua.LState, n int) io.Writer {
 	return wrapped
 }
 
-func CheckReader(L *lua.LState, n int) io.Reader {
+func CheckIOReader(L *lua.LState, n int) io.Reader {
 	any := L.CheckAny(n)
 	if ud, ok := any.(*lua.LUserData); ok {
 		if reader, ok := ud.Value.(io.Reader); ok {

--- a/io/wrappers.go
+++ b/io/wrappers.go
@@ -82,8 +82,9 @@ func (l *luaIOWrapper) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 	readString := lua.LVAsString(result)
-	copy(p, readString)
-	n = len(readString)
+	data := []byte(readString)
+	copy(p, data)
+	n = len(data)
 	return
 }
 

--- a/io/wrappers.go
+++ b/io/wrappers.go
@@ -30,6 +30,36 @@ func NewLuaIOWrapper(L *lua.LState, io lua.LValue) *luaIOWrapper {
 	return ret
 }
 
+func CheckWriter(L *lua.LState, n int) io.Writer {
+	any := L.CheckAny(n)
+	if ud, ok := any.(*lua.LUserData); ok {
+		if writer, ok := ud.Value.(io.Writer); ok {
+			return writer
+		}
+	}
+	wrapped := NewLuaIOWrapper(L, any)
+	if wrapped.writeMethod == nil {
+		L.ArgError(n, "expected writer")
+		return nil
+	}
+	return wrapped
+}
+
+func CheckReader(L *lua.LState, n int) io.Reader {
+	any := L.CheckAny(n)
+	if ud, ok := any.(*lua.LUserData); ok {
+		if reader, ok := ud.Value.(io.Reader); ok {
+			return reader
+		}
+	}
+	wrapped := NewLuaIOWrapper(L, any)
+	if wrapped.readMethod == nil {
+		L.ArgError(n, "expected reader")
+		return nil
+	}
+	return wrapped
+}
+
 func (l *luaIOWrapper) Read(p []byte) (n int, err error) {
 	if l.readMethod == nil {
 		return 0, errors.New("object does not have read method")

--- a/io/wrappers.go
+++ b/io/wrappers.go
@@ -30,6 +30,7 @@ func NewLuaIOWrapper(L *lua.LState, io lua.LValue) *luaIOWrapper {
 	return ret
 }
 
+//CheckIOWriter tries to cast to UserData and to io.Writer, otherwise it wraps and checks for "write" method
 func CheckIOWriter(L *lua.LState, n int) io.Writer {
 	any := L.CheckAny(n)
 	if ud, ok := any.(*lua.LUserData); ok {
@@ -45,6 +46,7 @@ func CheckIOWriter(L *lua.LState, n int) io.Writer {
 	return wrapped
 }
 
+//CheckIOReader tries to cast to UserData and to io.Reader, otherwise it wraps and checks for "read" method
 func CheckIOReader(L *lua.LState, n int) io.Reader {
 	any := L.CheckAny(n)
 	if ud, ok := any.(*lua.LUserData); ok {

--- a/io/wrappers_test.go
+++ b/io/wrappers_test.go
@@ -1,0 +1,79 @@
+package io
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	require.NoError(t, L.DoString(`io = require("io"); return io.open("/tmp/tst.out", "w")`))
+	writer := L.CheckAny(1)
+	L.Pop(L.GetTop())
+	wrapper := NewLuaIOWrapper(L, writer)
+	//goland:noinspection GoUnhandledErrorResult
+	defer wrapper.Close()
+	_, err := wrapper.Write([]byte("foo bar baz"))
+	require.NoError(t, err)
+	wrapper.Close()
+	data, err := ioutil.ReadFile("/tmp/tst.out")
+	require.NoError(t, err)
+	assert.Equal(t, "foo bar baz", string(data))
+}
+
+func TestRead(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), fs.ModePerm))
+	require.NoError(t, L.DoString(`io = require("io"); return io.open("/tmp/tst.in", "r")`))
+	reader := L.CheckAny(1)
+	L.Pop(L.GetTop())
+	wrapper := NewLuaIOWrapper(L, reader)
+	//goland:noinspection GoUnhandledErrorResult
+	defer wrapper.Close()
+	data, err := ioutil.ReadAll(wrapper)
+	require.NoError(t, err)
+	assert.Equal(t, "abc def ghi", string(data))
+}
+
+func TestSeek(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), fs.ModePerm))
+	require.NoError(t, L.DoString(`io = require("io"); return io.open("/tmp/tst.in", "r")`))
+	reader := L.CheckAny(1)
+	L.Pop(L.GetTop())
+	wrapper := NewLuaIOWrapper(L, reader)
+	//goland:noinspection GoUnhandledErrorResult
+	defer wrapper.Close()
+	_, err := wrapper.Seek(4, io.SeekStart)
+	require.NoError(t, err)
+	three := make([]byte, 3)
+	num, err := wrapper.Read(three)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, num)
+	assert.Equal(t, "def", string(three))
+
+	_, err = wrapper.Seek(1, io.SeekCurrent)
+	require.NoError(t, err)
+	num, err = wrapper.Read(three)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, num)
+	assert.Equal(t, "ghi", string(three))
+
+	_, err = wrapper.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	num, err = wrapper.Read(three)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, num)
+	assert.Equal(t, "abc", string(three))
+}

--- a/io/wrappers_test.go
+++ b/io/wrappers_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/stretchr/testify/require"
 	lua "github.com/yuin/gopher-lua"
 	"io"
-	"io/fs"
 	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -32,7 +32,7 @@ func TestRead(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), fs.ModePerm))
+	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), os.ModePerm))
 	require.NoError(t, L.DoString(`io = require("io"); return io.open("/tmp/tst.in", "r")`))
 	reader := L.CheckAny(1)
 	L.Pop(L.GetTop())
@@ -48,7 +48,7 @@ func TestSeek(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), fs.ModePerm))
+	require.NoError(t, ioutil.WriteFile("/tmp/tst.in", []byte("abc def ghi"), os.ModePerm))
 	require.NoError(t, L.DoString(`io = require("io"); return io.open("/tmp/tst.in", "r")`))
 	reader := L.CheckAny(1)
 	L.Pop(L.GetTop())

--- a/json/README.md
+++ b/json/README.md
@@ -24,3 +24,86 @@ if err then error(err) end
 local result = inspect(result, {newline="", indent=""})
 if not(result == [[{"a":{"b":1}}]]) then error("json.decode") end
 ```
+
+### decoder
+
+- With file
+
+```lua
+local json = require("json")
+local io = require("io")
+local inspect = require("inspect")
+
+f, err = io.open("myfile.json", "r")
+assert(not err, err)
+decoder = json.new_decoder(f)
+result, err = decoder.decode()
+f:close()
+assert(not err, err)
+print(inspect(result))
+```
+
+- With strings.Reader
+
+```lua
+local json = require("json")
+local strings = require("strings")
+local inspect = require("inspect")
+
+reader = strings.new_reader([[
+{
+  "foo": "bar",
+  "num": 123,
+  "arr": ["abc", "def", "ghi"]
+}
+]])
+decoder = yaml.new_decoder(reader)
+result, err = decoder.decode()
+f:close()
+assert(not err, err)
+print(inspect(result))
+```
+
+### encoder
+
+- with file
+
+```lua
+local json = require("json")
+local io = require("io")
+
+f, err = io.open('myfile.json', 'w')
+assert(not err, err)
+encoder = json.new_encoder(f)
+err = encoder.encode({ abc = "def", num = 123, arr = { 1, 2, 3 } })
+assert(not err, err)
+```
+
+- with strings.Builder
+
+```lua
+local json = require("json")
+local strings = require("strings")
+
+writer = strings.new_builder()
+encoder = json.new_encoder(writer)
+err = encoder.encode({ abc = "def", num = 123, arr = { 1, 2, 3 } })
+assert(not err, err)
+s = writer.string()
+print(s)
+```
+
+- with strings.Builder pretty printed
+
+```lua
+local json = require("json")
+local strings = require("strings")
+
+writer = strings.new_builder()
+encoder = json.new_encoder(writer)
+encoder.set_indent('', "  ")
+err = encoder.encode({ abc = "def", num = 123, arr = { 1, 2, 3 } })
+assert(not err, err)
+s = writer.string()
+print(s)
+```

--- a/json/README.md
+++ b/json/README.md
@@ -27,6 +27,8 @@ if not(result == [[{"a":{"b":1}}]]) then error("json.decode") end
 
 ### decoder
 
+Using a decoder allows reading from file or strings.Reader with input that has multiple values
+
 - With file
 
 ```lua
@@ -65,6 +67,8 @@ print(inspect(result))
 ```
 
 ### encoder
+
+Using an allows writing to file or strings.Builder and to write multiple values if desired
 
 - with file
 

--- a/json/api_test.go
+++ b/json/api_test.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/strings"
 	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func TestApi(t *testing.T) {
-	preload := tests.SeveralPreloadFuncs(Preload, inspect.Preload)
+	preload := tests.SeveralPreloadFuncs(
+		Preload,
+		inspect.Preload,
+		strings.Preload,
+	)
 	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "./test/test_api.lua"))
 }

--- a/json/decoder.go
+++ b/json/decoder.go
@@ -1,0 +1,72 @@
+package json
+
+import (
+	"encoding/json"
+	"github.com/vadv/gopher-lua-libs/io"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const (
+	jsonDecoderType = "json.Decoder"
+)
+
+func CheckDecoder(L *lua.LState, n int) *json.Decoder {
+	ud := L.CheckUserData(n)
+	if decoder, ok := ud.Value.(*json.Decoder); ok {
+		return decoder
+	}
+	L.ArgError(n, jsonDecoderType+" expected")
+	return nil
+}
+
+func LVDecoder(L *lua.LState, decoder *json.Decoder) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = decoder
+	L.SetMetatable(ud, L.GetTypeMetatable(jsonDecoderType))
+	return ud
+}
+
+func DecoderDecode(L *lua.LState) int {
+	decoder := CheckDecoder(L, 1)
+	L.Pop(L.GetTop())
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		L.Push(lua.LNil)
+		L.Push(lua.LString(err.Error()))
+		return 2
+	}
+	L.Push(decode(L, value))
+	return 1
+}
+
+func DecoderInputOffset(L *lua.LState) int {
+	decoder := CheckDecoder(L, 1)
+	L.Pop(L.GetTop())
+	L.Push(lua.LNumber(decoder.InputOffset()))
+	return 1
+}
+
+func DecoderMore(L *lua.LState) int {
+	decoder := CheckDecoder(L, 1)
+	L.Pop(L.GetTop())
+	L.Push(lua.LBool(decoder.More()))
+	return 1
+}
+
+func registerDecoder(L *lua.LState) {
+	mt := L.NewTypeMetatable(jsonDecoderType)
+	L.SetGlobal(jsonDecoderType, mt)
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"decode":       DecoderDecode,
+		"input_offset": DecoderInputOffset,
+		"more":         DecoderMore,
+	}))
+}
+
+func NewDecoder(L *lua.LState) int {
+	writer := L.CheckAny(1)
+	wrapper := io.NewLuaIOWrapper(L, writer)
+	decoder := json.NewDecoder(wrapper)
+	L.Push(LVDecoder(L, decoder))
+	return 1
+}

--- a/json/decoder.go
+++ b/json/decoder.go
@@ -26,7 +26,7 @@ func LVDecoder(L *lua.LState, decoder *json.Decoder) lua.LValue {
 	return ud
 }
 
-func DecoderDecode(L *lua.LState) int {
+func jsonDecoderDecode(L *lua.LState) int {
 	decoder := CheckDecoder(L, 1)
 	L.Pop(L.GetTop())
 	var value interface{}
@@ -39,14 +39,14 @@ func DecoderDecode(L *lua.LState) int {
 	return 1
 }
 
-func DecoderInputOffset(L *lua.LState) int {
+func jsonDecoderInputOffset(L *lua.LState) int {
 	decoder := CheckDecoder(L, 1)
 	L.Pop(L.GetTop())
 	L.Push(lua.LNumber(decoder.InputOffset()))
 	return 1
 }
 
-func DecoderMore(L *lua.LState) int {
+func jsonDecoderMore(L *lua.LState) int {
 	decoder := CheckDecoder(L, 1)
 	L.Pop(L.GetTop())
 	L.Push(lua.LBool(decoder.More()))
@@ -57,13 +57,13 @@ func registerDecoder(L *lua.LState) {
 	mt := L.NewTypeMetatable(jsonDecoderType)
 	L.SetGlobal(jsonDecoderType, mt)
 	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
-		"decode":       DecoderDecode,
-		"input_offset": DecoderInputOffset,
-		"more":         DecoderMore,
+		"decode":       jsonDecoderDecode,
+		"input_offset": jsonDecoderInputOffset,
+		"more":         jsonDecoderMore,
 	}))
 }
 
-func NewDecoder(L *lua.LState) int {
+func newJSONDecoder(L *lua.LState) int {
 	reader := io.CheckReader(L, 1)
 	L.Pop(L.GetTop())
 	decoder := json.NewDecoder(reader)

--- a/json/decoder.go
+++ b/json/decoder.go
@@ -64,9 +64,9 @@ func registerDecoder(L *lua.LState) {
 }
 
 func NewDecoder(L *lua.LState) int {
-	writer := L.CheckAny(1)
-	wrapper := io.NewLuaIOWrapper(L, writer)
-	decoder := json.NewDecoder(wrapper)
+	reader := io.CheckReader(L, 1)
+	L.Pop(L.GetTop())
+	decoder := json.NewDecoder(reader)
 	L.Push(LVDecoder(L, decoder))
 	return 1
 }

--- a/json/decoder.go
+++ b/json/decoder.go
@@ -10,7 +10,7 @@ const (
 	jsonDecoderType = "json.Decoder"
 )
 
-func CheckDecoder(L *lua.LState, n int) *json.Decoder {
+func CheckJSONDecoder(L *lua.LState, n int) *json.Decoder {
 	ud := L.CheckUserData(n)
 	if decoder, ok := ud.Value.(*json.Decoder); ok {
 		return decoder
@@ -19,7 +19,7 @@ func CheckDecoder(L *lua.LState, n int) *json.Decoder {
 	return nil
 }
 
-func LVDecoder(L *lua.LState, decoder *json.Decoder) lua.LValue {
+func LVJSONDecoder(L *lua.LState, decoder *json.Decoder) lua.LValue {
 	ud := L.NewUserData()
 	ud.Value = decoder
 	L.SetMetatable(ud, L.GetTypeMetatable(jsonDecoderType))
@@ -27,7 +27,7 @@ func LVDecoder(L *lua.LState, decoder *json.Decoder) lua.LValue {
 }
 
 func jsonDecoderDecode(L *lua.LState) int {
-	decoder := CheckDecoder(L, 1)
+	decoder := CheckJSONDecoder(L, 1)
 	L.Pop(L.GetTop())
 	var value interface{}
 	if err := decoder.Decode(&value); err != nil {
@@ -40,14 +40,14 @@ func jsonDecoderDecode(L *lua.LState) int {
 }
 
 func jsonDecoderInputOffset(L *lua.LState) int {
-	decoder := CheckDecoder(L, 1)
+	decoder := CheckJSONDecoder(L, 1)
 	L.Pop(L.GetTop())
 	L.Push(lua.LNumber(decoder.InputOffset()))
 	return 1
 }
 
 func jsonDecoderMore(L *lua.LState) int {
-	decoder := CheckDecoder(L, 1)
+	decoder := CheckJSONDecoder(L, 1)
 	L.Pop(L.GetTop())
 	L.Push(lua.LBool(decoder.More()))
 	return 1
@@ -67,6 +67,6 @@ func newJSONDecoder(L *lua.LState) int {
 	reader := io.CheckReader(L, 1)
 	L.Pop(L.GetTop())
 	decoder := json.NewDecoder(reader)
-	L.Push(LVDecoder(L, decoder))
+	L.Push(LVJSONDecoder(L, decoder))
 	return 1
 }

--- a/json/decoder.go
+++ b/json/decoder.go
@@ -64,7 +64,7 @@ func registerDecoder(L *lua.LState) {
 }
 
 func newJSONDecoder(L *lua.LState) int {
-	reader := io.CheckReader(L, 1)
+	reader := io.CheckIOReader(L, 1)
 	L.Pop(L.GetTop())
 	decoder := json.NewDecoder(reader)
 	L.Push(LVJSONDecoder(L, decoder))

--- a/json/encoder.go
+++ b/json/encoder.go
@@ -10,7 +10,7 @@ const (
 	jsonEncoderType = "json.Encoder"
 )
 
-func CheckEncoder(L *lua.LState, n int) *json.Encoder {
+func CheckJSONEncoder(L *lua.LState, n int) *json.Encoder {
 	ud := L.CheckUserData(n)
 	if encoder, ok := ud.Value.(*json.Encoder); ok {
 		return encoder
@@ -19,15 +19,15 @@ func CheckEncoder(L *lua.LState, n int) *json.Encoder {
 	return nil
 }
 
-func LVEncoder(L *lua.LState, encoder *json.Encoder) lua.LValue {
+func LVJSONEncoder(L *lua.LState, encoder *json.Encoder) lua.LValue {
 	ud := L.NewUserData()
 	ud.Value = encoder
 	L.SetMetatable(ud, L.GetTypeMetatable(jsonEncoderType))
 	return ud
 }
 
-func EncoderEncode(L *lua.LState) int {
-	encoder := CheckEncoder(L, 1)
+func jsonEncoderEncode(L *lua.LState) int {
+	encoder := CheckJSONEncoder(L, 1)
 	value := L.CheckAny(2)
 	L.Pop(L.GetTop())
 	err := encoder.Encode(jsonValue{
@@ -41,8 +41,8 @@ func EncoderEncode(L *lua.LState) int {
 	return 0
 }
 
-func EncoderSetIndent(L *lua.LState) int {
-	encoder := CheckEncoder(L, 1)
+func jsonEncoderSetIndent(L *lua.LState) int {
+	encoder := CheckJSONEncoder(L, 1)
 	prefix := L.CheckString(2)
 	indent := L.CheckString(3)
 	L.Pop(L.GetTop())
@@ -50,28 +50,28 @@ func EncoderSetIndent(L *lua.LState) int {
 	return 0
 }
 
-func EncoderSetEscapeHTML(L *lua.LState) int {
-	encoder := CheckEncoder(L, 1)
+func jsonEncoderSetEscapeHTML(L *lua.LState) int {
+	encoder := CheckJSONEncoder(L, 1)
 	on := L.CheckBool(2)
 	L.Pop(L.GetTop())
 	encoder.SetEscapeHTML(on)
 	return 0
 }
 
-func registerEncoder(L *lua.LState) {
+func registerJSONEncoder(L *lua.LState) {
 	mt := L.NewTypeMetatable(jsonEncoderType)
 	L.SetGlobal(jsonEncoderType, mt)
 	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
-		"encode":          EncoderEncode,
-		"set_indent":      EncoderSetIndent,
-		"set_escape_HTML": EncoderSetEscapeHTML,
+		"encode":          jsonEncoderEncode,
+		"set_indent":      jsonEncoderSetIndent,
+		"set_escape_HTML": jsonEncoderSetEscapeHTML,
 	}))
 }
 
-func NewEncoder(L *lua.LState) int {
+func newJSONEncoder(L *lua.LState) int {
 	writer := io.CheckWriter(L, 1)
 	L.Pop(L.GetTop())
 	encoder := json.NewEncoder(writer)
-	L.Push(LVEncoder(L, encoder))
+	L.Push(LVJSONEncoder(L, encoder))
 	return 1
 }

--- a/json/encoder.go
+++ b/json/encoder.go
@@ -69,7 +69,7 @@ func registerJSONEncoder(L *lua.LState) {
 }
 
 func newJSONEncoder(L *lua.LState) int {
-	writer := io.CheckWriter(L, 1)
+	writer := io.CheckIOWriter(L, 1)
 	L.Pop(L.GetTop())
 	encoder := json.NewEncoder(writer)
 	L.Push(LVJSONEncoder(L, encoder))

--- a/json/encoder.go
+++ b/json/encoder.go
@@ -1,0 +1,77 @@
+package json
+
+import (
+	"encoding/json"
+	"github.com/vadv/gopher-lua-libs/io"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const (
+	jsonEncoderType = "json.Encoder"
+)
+
+func CheckEncoder(L *lua.LState, n int) *json.Encoder {
+	ud := L.CheckUserData(n)
+	if encoder, ok := ud.Value.(*json.Encoder); ok {
+		return encoder
+	}
+	L.ArgError(n, jsonEncoderType+" expected")
+	return nil
+}
+
+func LVEncoder(L *lua.LState, encoder *json.Encoder) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = encoder
+	L.SetMetatable(ud, L.GetTypeMetatable(jsonEncoderType))
+	return ud
+}
+
+func EncoderEncode(L *lua.LState) int {
+	encoder := CheckEncoder(L, 1)
+	value := L.CheckAny(2)
+	L.Pop(L.GetTop())
+	err := encoder.Encode(jsonValue{
+		LValue:  value,
+		visited: make(map[*lua.LTable]bool),
+	})
+	if err != nil {
+		L.Push(lua.LString(err.Error()))
+		return 1
+	}
+	return 0
+}
+
+func EncoderSetIndent(L *lua.LState) int {
+	encoder := CheckEncoder(L, 1)
+	prefix := L.CheckString(2)
+	indent := L.CheckString(3)
+	L.Pop(L.GetTop())
+	encoder.SetIndent(prefix, indent)
+	return 0
+}
+
+func EncoderSetEscapeHTML(L *lua.LState) int {
+	encoder := CheckEncoder(L, 1)
+	on := L.CheckBool(2)
+	L.Pop(L.GetTop())
+	encoder.SetEscapeHTML(on)
+	return 0
+}
+
+func registerEncoder(L *lua.LState) {
+	mt := L.NewTypeMetatable(jsonEncoderType)
+	L.SetGlobal(jsonEncoderType, mt)
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"encode":          EncoderEncode,
+		"set_indent":      EncoderSetIndent,
+		"set_escape_HTML": EncoderSetEscapeHTML,
+	}))
+}
+
+func NewEncoder(L *lua.LState) int {
+	writer := L.CheckAny(1)
+	wrapper := io.NewLuaIOWrapper(L, writer)
+	encoder := json.NewEncoder(wrapper)
+	L.Push(LVEncoder(L, encoder))
+	return 1
+}

--- a/json/encoder.go
+++ b/json/encoder.go
@@ -69,9 +69,9 @@ func registerEncoder(L *lua.LState) {
 }
 
 func NewEncoder(L *lua.LState) int {
-	writer := L.CheckAny(1)
-	wrapper := io.NewLuaIOWrapper(L, writer)
-	encoder := json.NewEncoder(wrapper)
+	writer := io.CheckWriter(L, 1)
+	L.Pop(L.GetTop())
+	encoder := json.NewEncoder(writer)
 	L.Push(LVEncoder(L, encoder))
 	return 1
 }

--- a/json/loader.go
+++ b/json/loader.go
@@ -14,7 +14,7 @@ func Preload(L *lua.LState) {
 
 // Loader is the module loader function.
 func Loader(L *lua.LState) int {
-	registerEncoder(L)
+	registerJSONEncoder(L)
 	registerDecoder(L)
 
 	t := L.NewTable()
@@ -26,6 +26,6 @@ func Loader(L *lua.LState) int {
 var api = map[string]lua.LGFunction{
 	"decode":      Decode,
 	"encode":      Encode,
-	"new_encoder": NewEncoder,
-	"new_decoder": NewDecoder,
+	"new_encoder": newJSONEncoder,
+	"new_decoder": newJSONDecoder,
 }

--- a/json/loader.go
+++ b/json/loader.go
@@ -14,6 +14,9 @@ func Preload(L *lua.LState) {
 
 // Loader is the module loader function.
 func Loader(L *lua.LState) int {
+	registerEncoder(L)
+	registerDecoder(L)
+
 	t := L.NewTable()
 	L.SetFuncs(t, api)
 	L.Push(t)
@@ -21,6 +24,8 @@ func Loader(L *lua.LState) int {
 }
 
 var api = map[string]lua.LGFunction{
-	"decode": Decode,
-	"encode": Encode,
+	"decode":      Decode,
+	"encode":      Encode,
+	"new_encoder": NewEncoder,
+	"new_decoder": NewDecoder,
 }

--- a/json/test/test_api.lua
+++ b/json/test/test_api.lua
@@ -1,5 +1,6 @@
 local json = require("json")
 local inspect = require("inspect")
+local io = require("io")
 
 function TestJson(t)
     local jsonStringWithNull = [[{"a":{"b":1, "c":null}}]]
@@ -19,4 +20,38 @@ function TestJson(t)
         if result ~= jsonString then error("must be encode "..inspect(result)) end
         print("done: json.encode()")
     end)
+end
+
+function TestEncoder(t)
+    temp_file = '/tmp/tst.json'
+    os.remove(temp_file)
+    writer, err = io.open(temp_file, 'w')
+    assert(not err, err)
+    encoder = json.new_encoder(writer)
+    err = encoder:encode({foo="bar", bar="baz"})
+    assert(not err, err)
+    writer:close()
+
+    reader = io.open(temp_file, 'r')
+    contents = reader:read('*a')
+    assert(contents, "contents should not be empty")
+    contents = json.decode(contents)
+    assert(contents['foo'] == 'bar', string.format("%s ~= bar", contents['foo']))
+    assert(contents['bar'] == 'baz', string.format("%s ~= baz", contents['bar']))
+end
+
+function TestDecoder(t)
+    temp_file = '/tmp/tst.json'
+    os.remove(temp_file)
+    writer, err = io.open(temp_file, 'w')
+    assert(not err, err)
+    writer:write([[{"abc": "def", "num": 123}]])
+    writer:close()
+
+    reader = io.open(temp_file, 'r')
+    decoder = json.new_decoder(reader)
+    result, err = decoder:decode()
+    assert(not err, err)
+    assert(result['abc'] == 'def', string.format("%s ~= def", result['abc']))
+    assert(result['num'] == 123, string.format("%d ~= 123", result['num']))
 end

--- a/json/test/test_api.lua
+++ b/json/test/test_api.lua
@@ -50,6 +50,24 @@ function TestEncoderWithStringsBuffer(t)
     assert(s == expected, string.format([['%s' ~= '%s']], expected, s))
 end
 
+function TestEncoderWithPrettyPrinting(t)
+    builder = strings.new_builder()
+    encoder = json.new_encoder(builder)
+    encoder:set_indent('', "  ")
+    err = encoder:encode({abc="def", num=123, arr={1,2,3}})
+    s = strings.trim_suffix(builder:string(), "\n")
+    expected = [[{
+  "abc": "def",
+  "arr": [
+    1,
+    2,
+    3
+  ],
+  "num": 123
+}]]
+    assert(s == expected, string.format([['%s' ~= '%s']], expected, s))
+end
+
 function TestDecoder(t)
     temp_file = '/tmp/tst.json'
     os.remove(temp_file)

--- a/json/test/test_api.lua
+++ b/json/test/test_api.lua
@@ -93,3 +93,38 @@ function TestDecoderWithStringsReader(t)
     assert(result['abc'] == 'def', string.format("%s ~= def", result['abc']))
     assert(result['num'] == 123, string.format("%d ~= 123", result['num']))
 end
+
+function TestDecoder_reading_twice(t)
+    input = [[
+{"abc": "def"}
+{"num": 123}
+]]
+    reader = strings.new_reader(input)
+    decoder = json.new_decoder(reader)
+    first, err = decoder:decode()
+    assert(not err, err)
+    second, err = decoder:decode()
+    assert(not err, err)
+
+    s = first["abc"]
+    expected = "def"
+    assert(s == expected, string.format([['%s' ~= '%s']], s, expected))
+
+    num = second["num"]
+    expected = 123
+    assert(num == expected, string.format([['%d' ~= '%d']], num, expected))
+end
+
+function TestEncoder_writing_twice(t)
+    writer = strings.new_builder()
+    encoder = json.new_encoder(writer)
+    err = encoder:encode({abc="def"})
+    assert(not err, err)
+    encoder:encode({num=123})
+    assert(not err, err)
+    s = writer:string()
+    expected = [[{"abc":"def"}
+{"num":123}
+]]
+    assert(s == expected, string.format([['%s' ~= '%s']], s, expected))
+end

--- a/json/test/test_api.lua
+++ b/json/test/test_api.lua
@@ -120,7 +120,7 @@ function TestEncoder_writing_twice(t)
     encoder = json.new_encoder(writer)
     err = encoder:encode({abc="def"})
     assert(not err, err)
-    encoder:encode({num=123})
+    err = encoder:encode({num=123})
     assert(not err, err)
     s = writer:string()
     expected = [[{"abc":"def"}

--- a/pb/example_test.go
+++ b/pb/example_test.go
@@ -19,7 +19,7 @@ func ExampleAllParams() {
                 local bar = pb.new(count)
                 local template = string.format('%s {{ counters . }} {{percent . }} {{ etime . }}', '[custom template]')
 
-                err = bar:configure({writer='stdout', refresh_rate=2001, template=template})
+                err = bar:configure({writer='stdout', refresh_rate=3001, template=template})
                 if err then error(err) end
                 bar:start()
 

--- a/strings/README.md
+++ b/strings/README.md
@@ -28,3 +28,9 @@ local result = strings.contains("abcd", "d")
 -- Output: true
 ```
 
+### Reader/Writer classes often used with json+yaml Encoder/Decoder
+
+```lua
+reader = strings.new_reader([[{"foo":"bar","baz":"buz"}]])
+writer = strings.new_builder()
+```

--- a/strings/builder.go
+++ b/strings/builder.go
@@ -1,0 +1,48 @@
+package strings
+
+import (
+	lua "github.com/yuin/gopher-lua"
+	"strings"
+)
+
+const (
+	stringsBuilderType = "strings.Builder"
+)
+
+func CheckStringsBuilder(L *lua.LState, n int) *strings.Builder {
+	ud := L.CheckUserData(n)
+	if builder, ok := ud.Value.(*strings.Builder); ok {
+		return builder
+	}
+	L.ArgError(n, stringsBuilderType+" expected")
+	return nil
+}
+
+func LVStringsBuilder(L *lua.LState, builder *strings.Builder) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = builder
+	L.SetMetatable(ud, L.GetTypeMetatable(stringsBuilderType))
+	return ud
+}
+
+func stringsBuilderString(L *lua.LState) int {
+	builder := CheckStringsBuilder(L, 1)
+	s := builder.String()
+	L.Push(lua.LString(s))
+	return 1
+}
+
+func newStringsBuilder(L *lua.LState) int {
+	builder := &strings.Builder{}
+	L.Push(LVStringsBuilder(L, builder))
+	return 1
+}
+
+func registerStringsBuilder(L *lua.LState) {
+	mt := L.NewTypeMetatable(stringsBuilderType)
+	L.SetGlobal(stringsBuilderType, mt)
+	// TODO(scr): Does this need io methods exposed, or is String enough
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"string": stringsBuilderString,
+	}))
+}

--- a/strings/loader.go
+++ b/strings/loader.go
@@ -14,6 +14,9 @@ func Preload(L *lua.LState) {
 
 // Loader is the module loader function.
 func Loader(L *lua.LState) int {
+	registerStringsReader(L)
+	registerStringsBuilder(L)
+
 	t := L.NewTable()
 	L.SetFuncs(t, api)
 	L.Push(t)
@@ -28,4 +31,6 @@ var api = map[string]lua.LGFunction{
 	"has_prefix":  HasPrefix,
 	"has_suffix":  HasSuffix,
 	"contains":    Contains,
+	"new_reader":  newStringsReader,
+	"new_builder": newStringsBuilder,
 }

--- a/strings/reader.go
+++ b/strings/reader.go
@@ -1,0 +1,41 @@
+package strings
+
+import (
+	lua "github.com/yuin/gopher-lua"
+	"strings"
+)
+
+const (
+	stringsReaderType = "strings.Reader"
+)
+
+func CheckStringsReader(L *lua.LState, n int) *strings.Reader {
+	ud := L.CheckUserData(n)
+	if reader, ok := ud.Value.(*strings.Reader); ok {
+		return reader
+	}
+	L.ArgError(n, stringsReaderType+" expected")
+	return nil
+}
+
+func LVStringsReader(L *lua.LState, reader *strings.Reader) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = reader
+	L.SetMetatable(ud, L.GetTypeMetatable(stringsReaderType))
+	return ud
+}
+
+func newStringsReader(L *lua.LState) int {
+	s := L.CheckString(1)
+	L.Pop(L.GetTop())
+	reader := strings.NewReader(s)
+	L.Push(LVStringsReader(L, reader))
+	return 1
+}
+
+func registerStringsReader(L *lua.LState) {
+	mt := L.NewTypeMetatable(stringsReaderType)
+	L.SetGlobal(stringsReaderType, mt)
+	// TODO(scr): Does this need methods exposed, or is just the type sufficient for passing to json/yaml.NewDecoder
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{}))
+}

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -3,6 +3,7 @@
 ## Usage
 
 ### decode
+
 ```lua
 local yaml = require("yaml")
 local inspect = require("inspect")
@@ -13,20 +14,94 @@ a:
   b: 1
 ]]
 local result, err = yaml.decode(text)
-if err then error(err) end
-print(inspect(result, {newline="", indent=""}))
+if err then
+    error(err)
+end
+print(inspect(result, { newline = "", indent = "" }))
 -- Output:
 -- {a = {b = 1}}
 ```
 
 ### encode
+
 ```lua
     local yaml = require("yaml")
-    local encoded, err = yaml.encode({a = {b = 1}})
-    if err then error(err) end
+    local encoded, err = yaml.encode({ a = { b = 1 } })
+    if err then
+        error(err)
+    end
     print(encoded)
-	-- Output:
-	-- a:
-	--   b: 1
-	--
+    -- Output:
+    -- a:
+    --   b: 1
+    --
+```
+
+### decoder
+
+- With file
+
+```lua
+local yaml = require("yaml")
+local io = require("io")
+local inspect = require("inspect")
+
+f, err = io.open("myfile.yaml", "r")
+assert(not err, err)
+decoder = yaml.new_decoder(f)
+result, err = decoder.decode()
+f:close()
+assert(not err, err)
+print(inspect(result))
+```
+
+- With strings.Reader
+
+```lua
+local yaml = require("yaml")
+local strings = require("strings")
+local inspect = require("inspect")
+
+reader = strings.new_reader([[
+foo: bar
+num: 123
+arr:
+- abc
+- def
+- ghi
+]])
+decoder = yaml.new_decoder(reader)
+result, err = decoder.decode()
+f:close()
+assert(not err, err)
+print(inspect(result))
+```
+
+### encoder
+
+- with file
+
+```lua
+local yaml = require("yaml")
+local io = require("io")
+
+f, err = io.open('myfile.yaml', 'w')
+assert(not err, err)
+encoder = yaml.new_encoder(f)
+err = encoder.encode({ abc = "def", num = 123, arr = { 1, 2, 3 } })
+assert(not err, err)
+```
+
+- with strings.Builder
+
+```lua
+local yaml = require("yaml")
+local strings = require("strings")
+
+writer = strings.new_builder()
+encoder = yaml.new_encoder(writer)
+err = encoder.encode({ abc = "def", num = 123, arr = { 1, 2, 3 } })
+assert(not err, err)
+s = writer.string()
+print(s)
 ```

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -39,6 +39,8 @@ print(inspect(result, { newline = "", indent = "" }))
 
 ### decoder
 
+Using a decoder allows reading from file or strings.Reader with input that has multiple values
+
 - With file
 
 ```lua
@@ -78,6 +80,8 @@ print(inspect(result))
 ```
 
 ### encoder
+
+Using an allows writing to file or strings.Builder and to write multiple values if desired
 
 - with file
 

--- a/yaml/api_test.go
+++ b/yaml/api_test.go
@@ -2,10 +2,15 @@ package yaml
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/strings"
 	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
 )
 
 func TestApi(t *testing.T) {
-	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./test/test_api.lua"))
+	preload := tests.SeveralPreloadFuncs(
+		Preload,
+		strings.Preload,
+	)
+	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "./test/test_api.lua"))
 }

--- a/yaml/decoder.go
+++ b/yaml/decoder.go
@@ -1,0 +1,65 @@
+package yaml
+
+import (
+	"github.com/vadv/gopher-lua-libs/io"
+	lua "github.com/yuin/gopher-lua"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	yamlDecoderType = "yaml.Decoder"
+)
+
+func CheckYAMLDecoder(L *lua.LState, n int) *yaml.Decoder {
+	ud := L.CheckUserData(n)
+	if decoder, ok := ud.Value.(*yaml.Decoder); ok {
+		return decoder
+	}
+	L.ArgError(n, yamlDecoderType+" expected")
+	return nil
+}
+
+func LVYAMLDecoder(L *lua.LState, decoder *yaml.Decoder) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = decoder
+	L.SetMetatable(ud, L.GetTypeMetatable(yamlDecoderType))
+	return ud
+}
+
+func yamlDecoderDecode(L *lua.LState) int {
+	decoder := CheckYAMLDecoder(L, 1)
+	L.Pop(L.GetTop())
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		L.Push(lua.LNil)
+		L.Push(lua.LString(err.Error()))
+		return 2
+	}
+	L.Push(fromYAML(L, value))
+	return 1
+}
+
+func yamlDecoderSetStrict(L *lua.LState) int {
+	decoder := CheckYAMLDecoder(L, 1)
+	strict := L.CheckBool(2)
+	L.Pop(L.GetTop())
+	decoder.SetStrict(strict)
+	return 0
+}
+
+func registerYAMLDecoder(L *lua.LState) {
+	mt := L.NewTypeMetatable(yamlDecoderType)
+	L.SetGlobal(yamlDecoderType, mt)
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"decode":     yamlDecoderDecode,
+		"set_strict": yamlDecoderSetStrict,
+	}))
+}
+
+func newYAMLDecoder(L *lua.LState) int {
+	reader := io.CheckReader(L, 1)
+	L.Pop(L.GetTop())
+	decoder := yaml.NewDecoder(reader)
+	L.Push(LVYAMLDecoder(L, decoder))
+	return 1
+}

--- a/yaml/decoder.go
+++ b/yaml/decoder.go
@@ -57,7 +57,7 @@ func registerYAMLDecoder(L *lua.LState) {
 }
 
 func newYAMLDecoder(L *lua.LState) int {
-	reader := io.CheckReader(L, 1)
+	reader := io.CheckIOReader(L, 1)
 	L.Pop(L.GetTop())
 	decoder := yaml.NewDecoder(reader)
 	L.Push(LVYAMLDecoder(L, decoder))

--- a/yaml/encoder.go
+++ b/yaml/encoder.go
@@ -56,7 +56,7 @@ func registerYAMLEncoder(L *lua.LState) {
 }
 
 func newYAMLEncoder(L *lua.LState) int {
-	writer := io.CheckWriter(L, 1)
+	writer := io.CheckIOWriter(L, 1)
 	L.Pop(L.GetTop())
 	encoder := yaml.NewEncoder(writer)
 	L.Push(LVYAMLEncoder(L, encoder))

--- a/yaml/encoder.go
+++ b/yaml/encoder.go
@@ -1,0 +1,64 @@
+package yaml
+
+import (
+	"github.com/vadv/gopher-lua-libs/io"
+	lua "github.com/yuin/gopher-lua"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	yamlEncoderType = "yaml.Encoder"
+)
+
+func CheckYAMLEncoder(L *lua.LState, n int) *yaml.Encoder {
+	ud := L.CheckUserData(n)
+	if encoder, ok := ud.Value.(*yaml.Encoder); ok {
+		return encoder
+	}
+	L.ArgError(n, yamlEncoderType+" expected")
+	return nil
+}
+
+func LVYAMLEncoder(L *lua.LState, encoder *yaml.Encoder) lua.LValue {
+	ud := L.NewUserData()
+	ud.Value = encoder
+	L.SetMetatable(ud, L.GetTypeMetatable(yamlEncoderType))
+	return ud
+}
+
+func yamlEncoderEncode(L *lua.LState) int {
+	encoder := CheckYAMLEncoder(L, 1)
+	arg := L.CheckAny(2)
+	L.Pop(L.GetTop())
+	var value interface{}
+	err := L.GPCall(func(L *lua.LState) int {
+		visited := make(map[*lua.LTable]bool)
+		value = toYAML(L, visited, arg)
+		return 0
+	}, lua.LNil)
+	if err != nil {
+		L.Push(lua.LString(err.Error()))
+		return 1
+	}
+	if err = encoder.Encode(value); err != nil {
+		L.Push(lua.LString(err.Error()))
+		return 1
+	}
+	return 0
+}
+
+func registerYAMLEncoder(L *lua.LState) {
+	mt := L.NewTypeMetatable(yamlEncoderType)
+	L.SetGlobal(yamlEncoderType, mt)
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"encode": yamlEncoderEncode,
+	}))
+}
+
+func newYAMLEncoder(L *lua.LState) int {
+	writer := io.CheckWriter(L, 1)
+	L.Pop(L.GetTop())
+	encoder := yaml.NewEncoder(writer)
+	L.Push(LVYAMLEncoder(L, encoder))
+	return 1
+}

--- a/yaml/loader.go
+++ b/yaml/loader.go
@@ -14,6 +14,9 @@ func Preload(L *lua.LState) {
 
 // Loader is the module loader function.
 func Loader(L *lua.LState) int {
+	registerYAMLEncoder(L)
+	registerYAMLDecoder(L)
+
 	t := L.NewTable()
 	L.SetFuncs(t, api)
 	L.Push(t)
@@ -21,6 +24,8 @@ func Loader(L *lua.LState) int {
 }
 
 var api = map[string]lua.LGFunction{
-	"decode": Decode,
-	"encode": Encode,
+	"decode":      Decode,
+	"encode":      Encode,
+	"new_encoder": newYAMLEncoder,
+	"new_decoder": newYAMLDecoder,
 }

--- a/yaml/test/test_api.lua
+++ b/yaml/test/test_api.lua
@@ -187,7 +187,7 @@ function TestEncoder_writing_twice(t)
     expected = "def"
     err = encoder:encode({abc="def"})
     assert(not err, err)
-    encoder:encode({num=123})
+    err = encoder:encode({num=123})
     assert(not err, err)
     s = writer:string()
     expected = [[

--- a/yaml/test/test_api.lua
+++ b/yaml/test/test_api.lua
@@ -158,3 +158,42 @@ num: 123
     assert(result['abc'] == 'def', string.format("%s ~= def", result['abc']))
     assert(result['num'] == 123, string.format("%d ~= 123", result['num']))
 end
+
+function TestDecoder_reading_twice(t)
+    input = [[
+abc: def
+---
+num: 123
+]]
+    reader = strings.new_reader(input)
+    decoder = yaml.new_decoder(reader)
+    first, err = decoder:decode()
+    assert(not err, err)
+    second, err = decoder:decode()
+    assert(not err, err)
+
+    s = first["abc"]
+    expected = "def"
+    assert(s == expected, string.format([['%s' ~= '%s']], s, expected))
+
+    num = second["num"]
+    expected = 123
+    assert(num == expected, string.format([['%d' ~= '%d']], num, expected))
+end
+
+function TestEncoder_writing_twice(t)
+    writer = strings.new_builder()
+    encoder = yaml.new_encoder(writer)
+    expected = "def"
+    err = encoder:encode({abc="def"})
+    assert(not err, err)
+    encoder:encode({num=123})
+    assert(not err, err)
+    s = writer:string()
+    expected = [[
+abc: def
+---
+num: 123
+]]
+    assert(s == expected, string.format([['%s' ~= '%s']], s, expected))
+end


### PR DESCRIPTION
In order to support reading/writing from/to file, and dealing with multiple lines (json) or multiple sections (yaml with `---`), and to string via strings.Reader and strings.Buffer, add the corresponding types, methods, and tests.

Main goals:

1. "direct" File I/O (yes, there are intermediate interfaces, etc so it's not really direct
2. reading/writing multiple values - one json per line or yamls separated with `---`
3. pretty printing for json encoder via `set_indent('', '  ')`