### PR TITLE
add location parameter for time.parse

### DIFF
--- a/time/api.go
+++ b/time/api.go
@@ -27,10 +27,23 @@ func Sleep(L *lua.LState) int {
 	return 0
 }
 
-// Parse lua time.parse(value, layout) returns (number, error)
+// Parse lua time.parse(value, layout, ...location) returns (number, error)
 func Parse(L *lua.LState) int {
 	layout, value := L.CheckString(2), L.CheckString(1)
-	result, err := time.Parse(layout, value)
+	var (
+		err    error
+		result time.Time
+	)
+	if L.GetTop() > 2 {
+		location := L.CheckString(3)
+		var loc *time.Location
+		loc, err = time.LoadLocation(location)
+		if err == nil {
+			result, err = time.ParseInLocation(layout, value, loc)
+		}
+	} else {
+		result, err = time.Parse(layout, value)
+	}
 	if err != nil {
 		L.Push(lua.LNil)
 		L.Push(lua.LString(err.Error()))

--- a/time/test/test_api.lua
+++ b/time/test/test_api.lua
@@ -18,6 +18,11 @@ local _, err = time.parse("Dec  32 03:33:05 2018", "Jan  2 15:04:05 2006")
 if (err == nil) then error("time.parse(): must be error") end
 print("done: time.parse(): 2")
 
+local parse, err = time.parse("Dec  2 03:33:05 2018", "Jan  2 15:04:05 2006", "Asia/Shanghai")
+if err then error(err) end
+if not(parse == 1543721585 - 8 * 3600) then error("time.parse(): 3") end
+print("done: time.parse(): 3")
+
 local result, err = time.format(1543721585, "Jan  2 15:04:05 2006", "Europe/Moscow")
 if err then error(err) end
 if not(result == "Dec  2 06:33:05 2018") then error("time.format()") end


### PR DESCRIPTION
Sometimes when I use `time` package to parse time, I need to specify the time zone.