### PR TITLE
Update plugin to work more like goroutines

### DIFF
--- a/plugin/api.go
+++ b/plugin/api.go
@@ -3,7 +3,7 @@ package plugin
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"sync"
 	"time"
 
@@ -182,13 +182,14 @@ func DoStringWithPayload(L *lua.LState) int {
 }
 
 // Run lua plugin_ud:run()
-func Run(L *lua.LState) int {
+func Run(L *lua.LState) (nRet int) {
 	p := checkPlugin(L, 1)
 	go p.start()
 
 	defer func() {
 		if err := recover(); err != nil {
-			log.Fatal(err)
+			L.Push(lua.LString(fmt.Sprintf("%v", err)))
+			nRet = 1
 		}
 	}()
 
@@ -199,7 +200,7 @@ func Run(L *lua.LState) int {
 		p.Cond.Wait()
 	}
 
-	return 0
+	return
 }
 
 // IsRunning lua plugin_ud:is_running()

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -3,6 +3,12 @@ package plugin
 
 import (
 	"context"
+	"github.com/vadv/gopher-lua-libs/argparse"
+	"github.com/vadv/gopher-lua-libs/base64"
+	"github.com/vadv/gopher-lua-libs/cert_util"
+	"github.com/vadv/gopher-lua-libs/pprof"
+	"github.com/vadv/gopher-lua-libs/runtime"
+	"github.com/vadv/gopher-lua-libs/shellescape"
 	"sync"
 
 	"github.com/vadv/gopher-lua-libs/stats"
@@ -79,33 +85,42 @@ func (p *luaPlugin) setRunning(val bool) {
 func NewPluginState() *lua.LState {
 	state := lua.NewState()
 	// preload all
-	filepath.Preload(state)
-	http.Preload(state)
-	inspect.Preload(state)
-	ioutil.Preload(state)
-	json.Preload(state)
-	regexp.Preload(state)
-	strings.Preload(state)
-	tac.Preload(state)
-	tcp.Preload(state)
+	// TODO: refactor this so it doesn't have to be kept in sync with the libs.Preload
+	argparse.Preload(state)
+	base64.Preload(state)
 	time.Preload(state)
-	xmlpath.Preload(state)
+	strings.Preload(state)
+	filepath.Preload(state)
+	ioutil.Preload(state)
+	http.Preload(state)
+	regexp.Preload(state)
+	tac.Preload(state)
+	inspect.Preload(state)
 	yaml.Preload(state)
-	zabbix.Preload(state)
+	Preload(state)
+	cmd.Preload(state)
+	json.Preload(state)
+	tcp.Preload(state)
+	xmlpath.Preload(state)
+	db.Preload(state)
+	cert_util.Preload(state)
+	runtime.Preload(state)
+	shellescape.Preload(state)
 	telegram.Preload(state)
-	storage.Preload(state)
+	zabbix.Preload(state)
+	pprof.Preload(state)
+	prometheus.Preload(state)
+	pb.Preload(state)
 	crypto.Preload(state)
 	goos.Preload(state)
+	storage.Preload(state)
 	humanize.Preload(state)
-	db.Preload(state)
 	chef.Preload(state)
-	cmd.Preload(state)
 	template.Preload(state)
 	cloudwatch.Preload(state)
 	log.Preload(state)
-	prometheus.Preload(state)
-	pb.Preload(state)
 	stats.Preload(state)
+
 	return state
 }
 

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -60,6 +60,7 @@ func NewPluginState() *lua.LState {
 func (p *luaPlugin) start() {
 	p.Lock()
 	state := NewPluginState()
+	defer state.Close()
 	p.state = state
 	p.error = nil
 	p.running = true

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -3,7 +3,6 @@ package plugin
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -185,13 +184,6 @@ func DoStringWithPayload(L *lua.LState) int {
 func Run(L *lua.LState) (nRet int) {
 	p := checkPlugin(L, 1)
 	go p.start()
-
-	defer func() {
-		if err := recover(); err != nil {
-			L.Push(lua.LString(fmt.Sprintf("%v", err)))
-			nRet = 1
-		}
-	}()
 
 	// ensure it's started
 	p.Lock()

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -3,42 +3,7 @@ package plugin
 
 import (
 	"context"
-	"github.com/vadv/gopher-lua-libs/argparse"
-	"github.com/vadv/gopher-lua-libs/base64"
-	"github.com/vadv/gopher-lua-libs/cert_util"
-	"github.com/vadv/gopher-lua-libs/pprof"
-	"github.com/vadv/gopher-lua-libs/runtime"
-	"github.com/vadv/gopher-lua-libs/shellescape"
 	"sync"
-
-	"github.com/vadv/gopher-lua-libs/stats"
-
-	cloudwatch "github.com/vadv/gopher-lua-libs/aws/cloudwatch"
-	chef "github.com/vadv/gopher-lua-libs/chef"
-	cmd "github.com/vadv/gopher-lua-libs/cmd"
-	crypto "github.com/vadv/gopher-lua-libs/crypto"
-	db "github.com/vadv/gopher-lua-libs/db"
-	filepath "github.com/vadv/gopher-lua-libs/filepath"
-	goos "github.com/vadv/gopher-lua-libs/goos"
-	http "github.com/vadv/gopher-lua-libs/http"
-	humanize "github.com/vadv/gopher-lua-libs/humanize"
-	inspect "github.com/vadv/gopher-lua-libs/inspect"
-	ioutil "github.com/vadv/gopher-lua-libs/ioutil"
-	json "github.com/vadv/gopher-lua-libs/json"
-	log "github.com/vadv/gopher-lua-libs/log"
-	pb "github.com/vadv/gopher-lua-libs/pb"
-	prometheus "github.com/vadv/gopher-lua-libs/prometheus/client"
-	regexp "github.com/vadv/gopher-lua-libs/regexp"
-	storage "github.com/vadv/gopher-lua-libs/storage"
-	strings "github.com/vadv/gopher-lua-libs/strings"
-	tac "github.com/vadv/gopher-lua-libs/tac"
-	tcp "github.com/vadv/gopher-lua-libs/tcp"
-	telegram "github.com/vadv/gopher-lua-libs/telegram"
-	template "github.com/vadv/gopher-lua-libs/template"
-	time "github.com/vadv/gopher-lua-libs/time"
-	xmlpath "github.com/vadv/gopher-lua-libs/xmlpath"
-	yaml "github.com/vadv/gopher-lua-libs/yaml"
-	zabbix "github.com/vadv/gopher-lua-libs/zabbix"
 
 	lua "github.com/yuin/gopher-lua"
 )
@@ -84,43 +49,7 @@ func (p *luaPlugin) setRunning(val bool) {
 // NewPluginState return lua state
 func NewPluginState() *lua.LState {
 	state := lua.NewState()
-	// preload all
-	// TODO: refactor this so it doesn't have to be kept in sync with the libs.Preload
-	argparse.Preload(state)
-	base64.Preload(state)
-	time.Preload(state)
-	strings.Preload(state)
-	filepath.Preload(state)
-	ioutil.Preload(state)
-	http.Preload(state)
-	regexp.Preload(state)
-	tac.Preload(state)
-	inspect.Preload(state)
-	yaml.Preload(state)
-	Preload(state)
-	cmd.Preload(state)
-	json.Preload(state)
-	tcp.Preload(state)
-	xmlpath.Preload(state)
-	db.Preload(state)
-	cert_util.Preload(state)
-	runtime.Preload(state)
-	shellescape.Preload(state)
-	telegram.Preload(state)
-	zabbix.Preload(state)
-	pprof.Preload(state)
-	prometheus.Preload(state)
-	pb.Preload(state)
-	crypto.Preload(state)
-	goos.Preload(state)
-	storage.Preload(state)
-	humanize.Preload(state)
-	chef.Preload(state)
-	template.Preload(state)
-	cloudwatch.Preload(state)
-	log.Preload(state)
-	stats.Preload(state)
-
+	PreloadAll(state)
 	return state
 }
 

--- a/plugin/api_test.go
+++ b/plugin/api_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/inspect"
 	"github.com/vadv/gopher-lua-libs/tests"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 func TestApi(t *testing.T) {
 	preload := tests.SeveralPreloadFuncs(
+		inspect.Preload,
 		time.Preload,
 		ioutil.Preload,
 		Preload,

--- a/plugin/example_test.go
+++ b/plugin/example_test.go
@@ -22,27 +22,27 @@ func Example_package() {
         local i = 1
         while doCh:receive() do
             print(i)
-			doneCh:send(i)
+            doneCh:send(i)
             i = i + 1
         end
     ]]
 
-	-- Make synchronization channels and fire up the plugin
-	local doCh = channel.make(100)
-	local doneCh = channel.make(100)
+    -- Make synchronization channels and fire up the plugin
+    local doCh = channel.make(100)
+    local doneCh = channel.make(100)
     local print_plugin = plugin.do_string(plugin_body, doCh, doneCh)
     print_plugin:run()
 
-	-- Allow two iterations to proceed
-	doCh:send(nil)
-	local ok, got = doneCh:receive()
-	assert(ok and got == 1, string.format("ok = %s; got = %s", ok, got))
-	doCh:send(nil)
-	ok, got = doneCh:receive()
-	assert(ok and got == 2, string.format("ok = %s; got = %s", ok, got))
+    -- Allow two iterations to proceed
+    doCh:send(nil)
+    local ok, got = doneCh:receive()
+    assert(ok and got == 1, string.format("ok = %s; got = %s", ok, got))
+    doCh:send(nil)
+    ok, got = doneCh:receive()
+    assert(ok and got == 2, string.format("ok = %s; got = %s", ok, got))
 
-	-- Close the doCh and wait to ensure it's closed gracefully but stop just to be sure
-	doCh:close()
+    -- Close the doCh and wait to ensure it's closed gracefully but stop just to be sure
+    doCh:close()
     time.sleep(1)
     print_plugin:stop()
     time.sleep(1)

--- a/plugin/example_test.go
+++ b/plugin/example_test.go
@@ -47,7 +47,7 @@ func Example_package() {
     print_plugin:stop()
     time.sleep(1)
 
-	-- Ensure it's not still running
+    -- Ensure it's not still running
     assert(not print_plugin:is_running(), "still running")
 `
 	if err := state.DoString(source); err != nil {

--- a/plugin/example_test.go
+++ b/plugin/example_test.go
@@ -18,7 +18,7 @@ func Example_package() {
     local time = require("time")
 
     local plugin_body = [[
-		local doCh, doneCh = unpack(arg)
+        local doCh, doneCh = unpack(arg)
         local i = 1
         while doCh:receive() do
             print(i)

--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -18,10 +18,12 @@ func Loader(L *lua.LState) int {
 	pluginUd := L.NewTypeMetatable(`plugin_ud`)
 	L.SetGlobal(`plugin_ud`, pluginUd)
 	L.SetField(pluginUd, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
-		"run":        Run,
-		"error":      Error,
-		"stop":       Stop,
-		"is_running": IsRunning,
+		"run":          Run,
+		"error":        Error,
+		"stop":         Stop,
+		"wait":         Wait,
+		"is_running":   IsRunning,
+		"done_channel": DoneChannel,
 	}))
 
 	t := L.NewTable()

--- a/plugin/preload.go
+++ b/plugin/preload.go
@@ -1,0 +1,77 @@
+package plugin
+
+import (
+	"github.com/vadv/gopher-lua-libs/argparse"
+	"github.com/vadv/gopher-lua-libs/aws/cloudwatch"
+	"github.com/vadv/gopher-lua-libs/base64"
+	"github.com/vadv/gopher-lua-libs/cert_util"
+	"github.com/vadv/gopher-lua-libs/chef"
+	"github.com/vadv/gopher-lua-libs/cmd"
+	"github.com/vadv/gopher-lua-libs/crypto"
+	"github.com/vadv/gopher-lua-libs/db"
+	"github.com/vadv/gopher-lua-libs/filepath"
+	"github.com/vadv/gopher-lua-libs/goos"
+	"github.com/vadv/gopher-lua-libs/http"
+	"github.com/vadv/gopher-lua-libs/humanize"
+	"github.com/vadv/gopher-lua-libs/inspect"
+	"github.com/vadv/gopher-lua-libs/ioutil"
+	"github.com/vadv/gopher-lua-libs/json"
+	"github.com/vadv/gopher-lua-libs/log"
+	"github.com/vadv/gopher-lua-libs/pb"
+	"github.com/vadv/gopher-lua-libs/pprof"
+	prometheus "github.com/vadv/gopher-lua-libs/prometheus/client"
+	"github.com/vadv/gopher-lua-libs/regexp"
+	"github.com/vadv/gopher-lua-libs/runtime"
+	"github.com/vadv/gopher-lua-libs/shellescape"
+	"github.com/vadv/gopher-lua-libs/stats"
+	"github.com/vadv/gopher-lua-libs/storage"
+	"github.com/vadv/gopher-lua-libs/strings"
+	"github.com/vadv/gopher-lua-libs/tac"
+	"github.com/vadv/gopher-lua-libs/tcp"
+	"github.com/vadv/gopher-lua-libs/telegram"
+	"github.com/vadv/gopher-lua-libs/template"
+	"github.com/vadv/gopher-lua-libs/time"
+	"github.com/vadv/gopher-lua-libs/xmlpath"
+	"github.com/vadv/gopher-lua-libs/yaml"
+	"github.com/vadv/gopher-lua-libs/zabbix"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// PreloadAll preload all gopher lua packages - note it's needed here to prevent circular deps between plugin and libs
+func PreloadAll(L *lua.LState) {
+	Preload(L)
+
+	argparse.Preload(L)
+	base64.Preload(L)
+	cert_util.Preload(L)
+	chef.Preload(L)
+	cloudwatch.Preload(L)
+	cmd.Preload(L)
+	crypto.Preload(L)
+	db.Preload(L)
+	filepath.Preload(L)
+	goos.Preload(L)
+	http.Preload(L)
+	humanize.Preload(L)
+	inspect.Preload(L)
+	ioutil.Preload(L)
+	json.Preload(L)
+	log.Preload(L)
+	pb.Preload(L)
+	pprof.Preload(L)
+	prometheus.Preload(L)
+	regexp.Preload(L)
+	runtime.Preload(L)
+	shellescape.Preload(L)
+	stats.Preload(L)
+	storage.Preload(L)
+	strings.Preload(L)
+	tac.Preload(L)
+	tcp.Preload(L)
+	telegram.Preload(L)
+	template.Preload(L)
+	time.Preload(L)
+	xmlpath.Preload(L)
+	yaml.Preload(L)
+	zabbix.Preload(L)
+}

--- a/plugin/test/test_api.lua
+++ b/plugin/test/test_api.lua
@@ -105,29 +105,33 @@ function TestWait(t)
 
     t:Run("no timeout", function(t)
         local notimeout_plugin = plugin.do_string(plugin_quick_body)
-        notimeout_plugin:run()
-        local err = notimeout_plugin:wait()
+        local err = notimeout_plugin:run()
+        assert(not err, err)
+        err = notimeout_plugin:wait()
         assert(not err, err)
     end)
 
     t:Run("no timeout fails", function(t)
         local notimeout_plugin = plugin.do_string(plugin_quick_body_fail)
-        notimeout_plugin:run()
-        local err = notimeout_plugin:wait()
+        local err = notimeout_plugin:run()
+        assert(not err, err)
+        err = notimeout_plugin:wait()
         assert(err)
     end)
 
     t:Run("timeout ok", function(t)
         local notimeout_plugin = plugin.do_string(plugin_quick_body)
-        notimeout_plugin:run()
-        local err = notimeout_plugin:wait(1)
+        local err = notimeout_plugin:run()
+        assert(not err, err)
+        err = notimeout_plugin:wait(1)
         assert(not err, err)
     end)
 
     t:Run("timeout expires", function(t)
         local notimeout_plugin = plugin.do_string(plugin_slow_body)
-        notimeout_plugin:run()
-        local err = notimeout_plugin:wait(0.1)
+        local err =notimeout_plugin:run()
+        assert(not err, err)
+        err = notimeout_plugin:wait(0.1)
         assert(err)
     end)
 end
@@ -149,7 +153,8 @@ function TestMultipleWorkers(t)
     local resultCh = channel.make(100)
     for i = 1, 5 do
         worker_plugin = plugin.do_string(work_body, workCh, resultCh)
-        worker_plugin:run()
+        local err = worker_plugin:run()
+        assert(not err, err)
         table.insert(workers, worker_plugin)
         table.insert(worker_channels, worker_plugin:done_channel())
     end
@@ -163,7 +168,8 @@ function TestMultipleWorkers(t)
         resultCh:close()
     ]]
     local worker_watcher_plugin = plugin.do_string(worker_watcher_body, resultCh, worker_channels)
-    worker_watcher_plugin:run()
+    err = worker_watcher_plugin:run()
+    assert(not err, err)
 
     -- Fire up a producer of work
     local work_producer_body = [[
@@ -174,7 +180,8 @@ function TestMultipleWorkers(t)
         workCh:close()
     ]]
     local work_producer_plugin = plugin.do_string(work_producer_body, workCh)
-    work_producer_plugin:run()
+    err = work_producer_plugin:run()
+    assert(not err, err)
 
     -- Now just walk the results, which should close when all workers have exited
     local count = 0

--- a/plugin/test/test_api.lua
+++ b/plugin/test/test_api.lua
@@ -187,7 +187,6 @@ function TestMultipleWorkers(t)
     local count = 0
     local ok, result = resultCh:receive()
     while ok do
-        assert(ok)
         assert(result[1] * 2 == result[2], inspect(result))
         count = count + 1
         t:Log(inspect(result))

--- a/plugin/test/test_api.lua
+++ b/plugin/test/test_api.lua
@@ -205,3 +205,26 @@ function TestMultipleWorkers(t)
         assert(not worker:error(), string.format("worker %d error %s", i, worker:error()))
     end
 end
+
+function TestPassingFunction(t)
+    local plugin_body = [[
+        pcall(unpack(arg))
+    ]]
+
+    function sendMe(ic, oc)
+        local ok, msg = ic:receive()
+        if ok then
+            oc:send("Hello, "..msg)
+        end
+        oc:close()
+    end
+    local inCh = channel.make(100)
+    local outCh = channel.make(100)
+
+    local f_plugin = plugin.do_string(plugin_body, sendMe, inCh, outCh)
+    f_plugin:run()
+    inCh:send("test")
+    local ok, msg = outCh:receive()
+    assert(ok)
+    assert(msg == "Hello, test", msg)
+end

--- a/plugin/test/test_api.lua
+++ b/plugin/test/test_api.lua
@@ -68,3 +68,23 @@ end
         assert(data == test_payload, "data <> test_payload")
     end)
 end
+
+function TestArgs(t)
+    local plugin_body = [[
+        local ch, msg = unpack(arg)
+        assert(ch, tostring(ch))
+        assert(msg, tostring(msg))
+        ch:send(msg.." pong")
+        ch:close()
+    ]]
+    local ch = channel.make(1)
+    local args_plugin = plugin.do_string(plugin_body, ch, "ping")
+    args_plugin:run()
+    time.sleep(0.1)
+    local err = args_plugin:error()
+    assert(not err, err)
+    local ok, answer = ch:receive()
+    assert(ok)
+    assert(answer == "ping pong", answer)
+    args_plugin:stop()
+end

--- a/plugin/test/test_api.lua
+++ b/plugin/test/test_api.lua
@@ -208,7 +208,7 @@ end
 
 function TestPassingFunction(t)
     local plugin_body = [[
-        pcall(unpack(arg))
+        return pcall(unpack(arg))
     ]]
 
     function sendMe(ic, oc)

--- a/preload.go
+++ b/preload.go
@@ -1,78 +1,11 @@
 package libs
 
 import (
-	"github.com/vadv/gopher-lua-libs/argparse"
-	cloudwatch "github.com/vadv/gopher-lua-libs/aws/cloudwatch"
-	"github.com/vadv/gopher-lua-libs/base64"
-	cert_util "github.com/vadv/gopher-lua-libs/cert_util"
-	chef "github.com/vadv/gopher-lua-libs/chef"
-	cmd "github.com/vadv/gopher-lua-libs/cmd"
-	crypto "github.com/vadv/gopher-lua-libs/crypto"
-	db "github.com/vadv/gopher-lua-libs/db"
-	filepath "github.com/vadv/gopher-lua-libs/filepath"
-	goos "github.com/vadv/gopher-lua-libs/goos"
-	http "github.com/vadv/gopher-lua-libs/http"
-	humanize "github.com/vadv/gopher-lua-libs/humanize"
-	inspect "github.com/vadv/gopher-lua-libs/inspect"
-	ioutil "github.com/vadv/gopher-lua-libs/ioutil"
-	json "github.com/vadv/gopher-lua-libs/json"
-	log "github.com/vadv/gopher-lua-libs/log"
-	pb "github.com/vadv/gopher-lua-libs/pb"
 	plugin "github.com/vadv/gopher-lua-libs/plugin"
-	pprof "github.com/vadv/gopher-lua-libs/pprof"
-	prometheus "github.com/vadv/gopher-lua-libs/prometheus/client"
-	regexp "github.com/vadv/gopher-lua-libs/regexp"
-	runtime "github.com/vadv/gopher-lua-libs/runtime"
-	"github.com/vadv/gopher-lua-libs/shellescape"
-	"github.com/vadv/gopher-lua-libs/stats"
-	storage "github.com/vadv/gopher-lua-libs/storage"
-	strings "github.com/vadv/gopher-lua-libs/strings"
-	tac "github.com/vadv/gopher-lua-libs/tac"
-	tcp "github.com/vadv/gopher-lua-libs/tcp"
-	telegram "github.com/vadv/gopher-lua-libs/telegram"
-	template "github.com/vadv/gopher-lua-libs/template"
-	time "github.com/vadv/gopher-lua-libs/time"
-	xmlpath "github.com/vadv/gopher-lua-libs/xmlpath"
-	yaml "github.com/vadv/gopher-lua-libs/yaml"
-	zabbix "github.com/vadv/gopher-lua-libs/zabbix"
-
 	lua "github.com/yuin/gopher-lua"
 )
 
 // Preload preload all gopher lua packages
 func Preload(L *lua.LState) {
-	argparse.Preload(L)
-	base64.Preload(L)
-	time.Preload(L)
-	strings.Preload(L)
-	filepath.Preload(L)
-	ioutil.Preload(L)
-	http.Preload(L)
-	regexp.Preload(L)
-	tac.Preload(L)
-	inspect.Preload(L)
-	yaml.Preload(L)
-	plugin.Preload(L)
-	cmd.Preload(L)
-	json.Preload(L)
-	tcp.Preload(L)
-	xmlpath.Preload(L)
-	db.Preload(L)
-	cert_util.Preload(L)
-	runtime.Preload(L)
-	shellescape.Preload(L)
-	telegram.Preload(L)
-	zabbix.Preload(L)
-	pprof.Preload(L)
-	prometheus.Preload(L)
-	pb.Preload(L)
-	crypto.Preload(L)
-	goos.Preload(L)
-	storage.Preload(L)
-	humanize.Preload(L)
-	chef.Preload(L)
-	template.Preload(L)
-	cloudwatch.Preload(L)
-	log.Preload(L)
-	stats.Preload(L)
+	plugin.PreloadAll(L)
 }


### PR DESCRIPTION
Add a few more features to plugin to make it work more like go routines:

1. Ensure the go p.start is really started (with `sync.Cond` and `started`) - so we know that the struct is consistently started when calling methods on it
2. Add the ability to pass simple args - those that don't rely on metatables such as string, number, channel and simple tables
3. Add a `doneCh` which can be waited on by other plugin instances since a channel may be passed
4. Add convenience `wait` that waits for doneCh and returns error
5. Wrote a few unit test cases to show how to fire up plugins like goroutines, and communicate with channels.
6. Solved the dependency loop by moving libs.Preload down to plugins and calling it from libs.Preload - so there's only one source of truth and each plugin has all the things loaded.
7. Allow passing functions too as long as they aren't closures… allowing a plugin body like `pcall(unpack(arg))`