### PR TITLE
strings: register type in package and not globally

### DIFF
--- a/strings/builder.go
+++ b/strings/builder.go
@@ -39,10 +39,10 @@ func newStringsBuilder(L *lua.LState) int {
 	return 1
 }
 
-func registerStringsBuilder(L *lua.LState) {
+func registerStringsBuilder(L *lua.LState) lua.LValue {
 	mt := L.NewTypeMetatable(stringsBuilderType)
-	L.SetGlobal(stringsBuilderType, mt)
 	writerTable := lio.WriterFuncTable(L)
 	L.SetField(writerTable, "string", L.NewFunction(stringsBuilderString))
 	L.SetField(mt, "__index", writerTable)
+	return mt
 }

--- a/strings/loader.go
+++ b/strings/loader.go
@@ -14,10 +14,12 @@ func Preload(L *lua.LState) {
 
 // Loader is the module loader function.
 func Loader(L *lua.LState) int {
-	registerStringsReader(L)
-	registerStringsBuilder(L)
+	readerMt := registerStringsReader(L)
+	builderMt := registerStringsBuilder(L)
 
 	t := L.NewTable()
+	t.RawSetString("Reader", readerMt)
+	t.RawSetString("Builder", builderMt)
 	L.SetFuncs(t, api)
 	L.Push(t)
 	return 1

--- a/strings/reader.go
+++ b/strings/reader.go
@@ -34,9 +34,9 @@ func newStringsReader(L *lua.LState) int {
 	return 1
 }
 
-func registerStringsReader(L *lua.LState) {
+func registerStringsReader(L *lua.LState) lua.LValue {
 	mt := L.NewTypeMetatable(stringsReaderType)
-	L.SetGlobal(stringsReaderType, mt)
 	readerTable := io.ReaderFuncTable(L)
 	L.SetField(mt, "__index", readerTable)
+	return mt
 }

--- a/strings/test/test_api.lua
+++ b/strings/test/test_api.lua
@@ -36,11 +36,25 @@ function TestReader(t)
     assert(got == s, string.format("'%s' ~= '%s'", got, s))
 end
 
+function TestReaderMetatable(t)
+    local reader = strings.new_reader("")
+    local got = getmetatable(reader)
+    local expected = strings.Reader
+    assert(got == expected, string.format("'%s' ~= '%s'", got, expected))
+end
+
 function TestBuilder(t)
     local builder = strings.new_builder()
     builder:write("foo", "bar", 123)
     local got = builder:string()
     assert(got == "foobar123", string.format("'%s' ~= '%s'", got, "foobar123"))
+end
+
+function TestBuilderMetatable(t)
+    local builder = strings.new_builder()
+    local got = getmetatable(builder)
+    local expected = strings.Builder
+    assert(got == expected, string.format("'%s' ~= '%s'", got, expected))
 end
 
 function TestTrimSpace(t)


### PR DESCRIPTION
Currently strings module create globals for types and not locally to package.

This merge request creates `Builder` and `Reader` for metatable instead of global variables `strings.Builder` and `strings.Reader`. These globals also contains a dot inside name so access would not be so easy.