### PR TITLE
README: go install and directly copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ go get github.com/vadv/gopher-lua-libs
 
 For the quick overview you can use standalone interpreter with listed libs. Examples and documentation for modules can be found in their directories.
 ```
-go get github.com/vadv/gopher-lua-libs/cmd/glua-libs
+go install github.com/vadv/gopher-lua-libs/cmd/glua-libs@latest
 
-$ glua-libs example.lua
+glua-libs example.lua
 ```
 
 This example shows basic usage of this libs in your code


### PR DESCRIPTION
Command mentioned in `README.md` does not install actually command.

This pull request removes also the `$` before the command to make copy&past easier. Alternative would be to add `$` to both commands.