### PR TITLE
Add bitwise operations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ go get github.com/vadv/gopher-lua-libs
 * [xmlpath](/xmlpath) [gopkg.in/xmlpath.v2](https://gopkg.in/xmlpath.v2) port
 * [yaml](/yaml) [gopkg.in/yaml.v2](https://gopkg.in/yaml.v2) port
 * [zabbix](/zabbix) zabbix bot
+* [bit](/bit) bitwise operations
 
 
 ## Usage

--- a/bit/README.md
+++ b/bit/README.md
@@ -1,0 +1,16 @@
+# stats [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/bit?bit.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/stats)
+
+## Usage
+
+```lua
+local stats = require("bit")
+
+local result, _ = bit.band(1, 0)
+print(result)
+-- Output: 0
+
+local result, _ = stats.lshift(10, 5)
+print(result)
+-- Output: 320
+```
+

--- a/bit/README.md
+++ b/bit/README.md
@@ -1,4 +1,4 @@
-# stats [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/bit?bit.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/bit)
+# bit [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/bit?bit.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/bit)
 
 ## Usage
 

--- a/bit/README.md
+++ b/bit/README.md
@@ -1,15 +1,15 @@
-# stats [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/bit?bit.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/stats)
+# stats [![GoDoc](https://godoc.org/github.com/vadv/gopher-lua-libs/bit?bit.svg)](https://godoc.org/github.com/vadv/gopher-lua-libs/bit)
 
 ## Usage
 
 ```lua
-local stats = require("bit")
+local bit = require("bit")
 
 local result, _ = bit.band(1, 0)
 print(result)
 -- Output: 0
 
-local result, _ = stats.lshift(10, 5)
+local result, _ = bit.lshift(10, 5)
 print(result)
 -- Output: 320
 ```

--- a/bit/api.go
+++ b/bit/api.go
@@ -56,7 +56,7 @@ func Not(l *lua.LState) int {
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.LString(err.Error()))
-		return 1
+		return 2
 	}
 	l.Push(lua.LNumber(^val))
 	return 1

--- a/bit/api.go
+++ b/bit/api.go
@@ -23,13 +23,14 @@ const (
 func Bitwise(kind op) lua.LGFunction {
 	return func(l *lua.LState) int {
 		if kind > rs {
-			l.Push(lua.LString("invalid type of operation"))
-			return 1
+			l.RaiseError("unsupported operation type")
+			return 0
 		}
 		val1, val2, err := prepareParams(l)
 		if err != nil {
+			l.Push(lua.LNil)
 			l.Push(lua.LString(err.Error()))
-			return 1
+			return 2
 		}
 		var ret uint32
 		switch kind {
@@ -53,6 +54,7 @@ func Bitwise(kind op) lua.LGFunction {
 func Not(l *lua.LState) int {
 	val, err := intToU32(l.CheckInt(1))
 	if err != nil {
+		l.Push(lua.LNil)
 		l.Push(lua.LString(err.Error()))
 		return 1
 	}

--- a/bit/api.go
+++ b/bit/api.go
@@ -1,0 +1,82 @@
+// Package strings implements golang package montanaflynn/stats functionality for lua.
+package stats
+
+import (
+	"fmt"
+	"math"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+type op uint
+
+const (
+	and op = iota
+	or
+	not
+	xor
+	ls
+	rs
+)
+
+// ShiftLeft
+func Bitwise(kind op) lua.LGFunction {
+	return func(l *lua.LState) int {
+		if kind > rs {
+			l.Push(lua.LString("invalid type of operation"))
+			return 1
+		}
+		val1, val2, err := prepareParams(l)
+		if err != nil {
+			l.Push(lua.LString(err.Error()))
+			return 1
+		}
+		var ret uint32
+		switch kind {
+		case and:
+			ret = val1 & val2
+		case or:
+			ret = val1 | val2
+		case xor:
+			ret = val1 ^ val2
+		case ls:
+			ret = val1 << val2
+		case rs:
+			ret = val1 >> val2
+		}
+		l.Push(lua.LNumber(ret))
+		return 1
+	}
+}
+
+func Not(l *lua.LState) int {
+	val, err := intToU32(l.CheckInt(1))
+	if err != nil {
+		l.Push(lua.LString(err.Error()))
+		return 1
+	}
+	l.Push(lua.LNumber(^val))
+	return 1
+}
+
+func prepareParams(l *lua.LState) (val, pos uint32, err error) {
+	val, err = intToU32(l.CheckInt(1))
+	if err != nil {
+		return 0, 0, err
+	}
+	pos, err = intToU32(l.CheckInt(2))
+	if err != nil {
+		return 0, 0, err
+	}
+	return
+}
+
+func intToU32(i int) (uint32, error) {
+	if i < 0 {
+		return 0, fmt.Errorf("cannot convert negative int %d to uint32", i)
+	}
+	if i > math.MaxUint32 {
+		return 0, fmt.Errorf("int %d overflows uint32", i)
+	}
+	return uint32(i), nil
+}

--- a/bit/api.go
+++ b/bit/api.go
@@ -1,5 +1,5 @@
-// Package strings implements golang package montanaflynn/stats functionality for lua.
-package stats
+// Package bit implements Go bitwise operations functionality for Lua.
+package bit
 
 import (
 	"fmt"
@@ -19,7 +19,7 @@ const (
 	rs
 )
 
-// ShiftLeft
+// Bitwise returns a Lua function used for bitwise operations.
 func Bitwise(kind op) lua.LGFunction {
 	return func(l *lua.LState) int {
 		if kind > rs {
@@ -49,6 +49,7 @@ func Bitwise(kind op) lua.LGFunction {
 	}
 }
 
+// Not implements bitwise not.
 func Not(l *lua.LState) int {
 	val, err := intToU32(l.CheckInt(1))
 	if err != nil {
@@ -59,12 +60,12 @@ func Not(l *lua.LState) int {
 	return 1
 }
 
-func prepareParams(l *lua.LState) (val, pos uint32, err error) {
-	val, err = intToU32(l.CheckInt(1))
+func prepareParams(l *lua.LState) (val1, val2 uint32, err error) {
+	val1, err = intToU32(l.CheckInt(1))
 	if err != nil {
 		return 0, 0, err
 	}
-	pos, err = intToU32(l.CheckInt(2))
+	val2, err = intToU32(l.CheckInt(2))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/bit/api_test.go
+++ b/bit/api_test.go
@@ -1,0 +1,11 @@
+package stats
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vadv/gopher-lua-libs/tests"
+	"testing"
+)
+
+func TestApi(t *testing.T) {
+	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./test/test_api.lua"))
+}

--- a/bit/api_test.go
+++ b/bit/api_test.go
@@ -8,5 +8,6 @@ import (
 )
 
 func TestApi(t *testing.T) {
-	assert.NotZero(t, tests.RunLuaTestFile(t, Preload, "./test/test_api.lua"))
+	preload := tests.SeveralPreloadFuncs(Preload)
+	assert.NotZero(t, tests.RunLuaTestFile(t, preload, "./test/test_api.lua"))
 }

--- a/bit/api_test.go
+++ b/bit/api_test.go
@@ -1,9 +1,10 @@
-package stats
+package bit
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vadv/gopher-lua-libs/tests"
-	"testing"
 )
 
 func TestApi(t *testing.T) {

--- a/bit/loader.go
+++ b/bit/loader.go
@@ -1,4 +1,4 @@
-package stats
+package bit
 
 import lua "github.com/yuin/gopher-lua"
 

--- a/bit/loader.go
+++ b/bit/loader.go
@@ -2,7 +2,7 @@ package bit
 
 import lua "github.com/yuin/gopher-lua"
 
-// Preload adds stats to the given Lua state's package.preload table. After it
+// Preload adds bit to the given Lua state's package.preload table. After it
 // has been preloaded, it can be loaded using require:
 //
 //	local bit = require("bit")

--- a/bit/loader.go
+++ b/bit/loader.go
@@ -1,0 +1,28 @@
+package stats
+
+import lua "github.com/yuin/gopher-lua"
+
+// Preload adds stats to the given Lua state's package.preload table. After it
+// has been preloaded, it can be loaded using require:
+//
+//	local bit = require("bit")
+func Preload(l *lua.LState) {
+	l.PreloadModule("bit", Loader)
+}
+
+// Loader is the module loader function.
+func Loader(L *lua.LState) int {
+	t := L.NewTable()
+	L.SetFuncs(t, api)
+	L.Push(t)
+	return 1
+}
+
+var api = map[string]lua.LGFunction{
+	"band":   Bitwise(and),
+	"bor":    Bitwise(or),
+	"bxor":   Bitwise(xor),
+	"lshift": Bitwise(ls),
+	"rshift": Bitwise(rs),
+	"bnot":   Not,
+}

--- a/bit/test/test_api.lua
+++ b/bit/test/test_api.lua
@@ -1,0 +1,55 @@
+local bit = require("bit")
+
+function Test_and(t)
+    local result, err = bit.band(1, 0)
+    assert(not err, err)
+    assert(result == 0, "and get: " .. tostring(result))
+    result, err = bit.band(5, 6)
+    assert(not err, err)
+    assert(result == 4, "and get: " .. tostring(result))
+end
+
+function Test_or(t)
+    local result, err = bit.bor(1, 0)
+    assert(not err, err)
+    assert(result == 1, "or get: " .. tostring(result))
+    result, err = bit.bor(5, 6)
+    assert(not err, err)
+    assert(result == 7, "or get: " .. tostring(result))
+end
+
+function Test_xor(t)
+    local result, err = bit.bxor(1, 0)
+    assert(not err, err)
+    assert(result == 1, "xor get: " .. tostring(result))
+    result, err = bit.bxor(5, 6)
+    assert(not err, err)
+    assert(result == 3, "xor get: " .. tostring(result))
+end
+
+function Test_left_shift(t)
+    local result, err = bit.lshift(1, 0)
+    assert(not err, err)
+    assert(result == 1, "left_shift get: " .. tostring(result))
+    result, err = bit.lshift(0xFF, 8)
+    assert(not err, err)
+    assert(result == 65280, "left_shift get: " .. tostring(result))
+end
+
+function Test_right_shift(t)
+    local result, err = bit.rshift(42, 2)
+    assert(not err, err)
+    assert(result == 10, "right_shift get: " .. tostring(result))
+    result, err = bit.rshift(0xFF, 4)
+    assert(not err, err)
+    assert(result == 15, "right_shift get: " .. tostring(result))
+end
+
+function Test_not(t)
+    local result, err = bit.bnot(65536)
+    assert(not err, err)
+    assert(result == 4294901759, "not get: " .. tostring(result))
+    result, err = bit.bnot(4294901759)
+    assert(not err, err)
+    assert(result == 65536, "not get: " .. tostring(result))
+end

--- a/bit/test/test_api.lua
+++ b/bit/test/test_api.lua
@@ -1,55 +1,129 @@
-local bit = require("bit")
+local bit = require 'bit'
+local assert = require 'assert'
 
-function Test_and(t)
-    local result, err = bit.band(1, 0)
-    assert(not err, err)
-    assert(result == 0, "and get: " .. tostring(result))
-    result, err = bit.band(5, 6)
-    assert(not err, err)
-    assert(result == 4, "and get: " .. tostring(result))
+function TestAnd(t)
+    local tests = {
+        {
+            input1 = 1,
+            input2 = 0,
+            expected = 0,
+        },
+        {
+            input1 = 111,
+            input2 = 222,
+            expected = 78,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run(tostring(tt.input1).." and "..tostring(tt.input2) , function(t)
+            local got = bit.band(tt.input1, tt.input2)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end
 
-function Test_or(t)
-    local result, err = bit.bor(1, 0)
-    assert(not err, err)
-    assert(result == 1, "or get: " .. tostring(result))
-    result, err = bit.bor(5, 6)
-    assert(not err, err)
-    assert(result == 7, "or get: " .. tostring(result))
+
+function TestOr(t)
+    local tests = {
+        {
+            input1 = 1,
+            input2 = 0,
+            expected = 1,
+        },
+        {
+            input1 = 111,
+            input2 = 222,
+            expected = 255,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run(tostring(tt.input1).." or "..tostring(tt.input2), function(t)
+            local got = bit.bor(tt.input1, tt.input2)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end
 
-function Test_xor(t)
-    local result, err = bit.bxor(1, 0)
-    assert(not err, err)
-    assert(result == 1, "xor get: " .. tostring(result))
-    result, err = bit.bxor(5, 6)
-    assert(not err, err)
-    assert(result == 3, "xor get: " .. tostring(result))
+
+
+function TestXor(t)
+    local tests = {
+        {
+            input1 = 1,
+            input2 = 0,
+            expected = 1,
+        },
+        {
+            input1 = 111,
+            input2 = 222,
+            expected = 177,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run(tostring(tt.input1).." xor "..tostring(tt.input2), function(t)
+            local got = bit.bxor(tt.input1, tt.input2)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end
 
-function Test_left_shift(t)
-    local result, err = bit.lshift(1, 0)
-    assert(not err, err)
-    assert(result == 1, "left_shift get: " .. tostring(result))
-    result, err = bit.lshift(0xFF, 8)
-    assert(not err, err)
-    assert(result == 65280, "left_shift get: " .. tostring(result))
+function TestLShift(t)
+    local tests = {
+        {
+            input1 = 123456,
+            input2 = 8,
+            expected = 31604736,
+        },
+        {
+            input1 = 0XFF,
+            input2 = 8,
+            expected = 65280,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run(tostring(tt.input1).." << "..tostring(tt.input2), function(t)
+            local got = bit.lshift(tt.input1, tt.input2)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end
 
-function Test_right_shift(t)
-    local result, err = bit.rshift(42, 2)
-    assert(not err, err)
-    assert(result == 10, "right_shift get: " .. tostring(result))
-    result, err = bit.rshift(0xFF, 4)
-    assert(not err, err)
-    assert(result == 15, "right_shift get: " .. tostring(result))
+function TestRShift(t)
+    local tests = {
+        {
+            input1 = 123456,
+            input2 = 8,
+            expected = 482,
+        },
+        {
+            input1 = 0XFF,
+            input2 = 1,
+            expected = 0x7F,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run(tostring(tt.input1).." >> "..tostring(tt.input2), function(t)
+            local got = bit.rshift(tt.input1, tt.input2)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end
 
-function Test_not(t)
-    local result, err = bit.bnot(65536)
-    assert(not err, err)
-    assert(result == 4294901759, "not get: " .. tostring(result))
-    result, err = bit.bnot(4294901759)
-    assert(not err, err)
-    assert(result == 65536, "not get: " .. tostring(result))
+function TestNot(t)
+    local tests = {
+        {
+            input = 65536,
+            expected = 4294901759,
+        },
+        {
+            input = 4294901759,
+            expected = 65536,
+        }
+    }
+    for _, tt in ipairs(tests) do
+        t:Run("not "..tostring(tt.input), function(t)
+            local got = bit.bnot(tt.input)
+            assert:Equal(t, tt.expected, got)
+        end)
+    end
 end

--- a/bit/test/test_api.lua
+++ b/bit/test/test_api.lua
@@ -4,6 +4,18 @@ local assert = require 'assert'
 function TestAnd(t)
     local tests = {
         {
+            input1 = -3,
+            input2 = 23,
+            expected = nil,
+            err = "cannot convert negative int -3 to uint32",
+        },
+        {
+            input1 = 4294967296,
+            input2 = 23,
+            expected = nil,
+            err = "int 4294967296 overflows uint32",
+        },
+        {
             input1 = 1,
             input2 = 0,
             expected = 0,
@@ -15,16 +27,28 @@ function TestAnd(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run(tostring(tt.input1).." and "..tostring(tt.input2) , function(t)
-            local got = bit.band(tt.input1, tt.input2)
+        t:Run(tostring(tt.input1) .. " and " .. tostring(tt.input2), function(t)
+            local got, err = bit.band(tt.input1, tt.input2)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end
 
-
 function TestOr(t)
     local tests = {
+        {
+            input1 = 5,
+            input2 = -423,
+            expected = nil,
+            err = "cannot convert negative int -423 to uint32",
+        },
+                {
+            input1 = 123,
+            input2 = 4294967296,
+            expected = nil,
+            err = "int 4294967296 overflows uint32",
+        },
         {
             input1 = 1,
             input2 = 0,
@@ -37,17 +61,28 @@ function TestOr(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run(tostring(tt.input1).." or "..tostring(tt.input2), function(t)
-            local got = bit.bor(tt.input1, tt.input2)
+        t:Run(tostring(tt.input1) .. " or " .. tostring(tt.input2), function(t)
+            local got, err = bit.bor(tt.input1, tt.input2)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end
 
-
-
 function TestXor(t)
     local tests = {
+        {
+            input1 = -1,
+            input2 = -46,
+            expected = nil,
+            err = "cannot convert negative int -1 to uint32",
+        },
+        {
+            input1 = 4294967300,
+            input2 = 46,
+            expected = nil,
+            err = "int 4294967300 overflows uint32",
+        },
         {
             input1 = 1,
             input2 = 0,
@@ -60,15 +95,28 @@ function TestXor(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run(tostring(tt.input1).." xor "..tostring(tt.input2), function(t)
-            local got = bit.bxor(tt.input1, tt.input2)
+        t:Run(tostring(tt.input1) .. " xor " .. tostring(tt.input2), function(t)
+            local got, err = bit.bxor(tt.input1, tt.input2)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end
 
 function TestLShift(t)
     local tests = {
+        {
+            input1 = 0,
+            input2 = -10,
+            expected = nil,
+            err = "cannot convert negative int -10 to uint32",
+        },
+        {
+            input1 = 4294967297,
+            input2 = 4294967298,
+            expected = nil,
+            err = "int 4294967297 overflows uint32",
+        },
         {
             input1 = 123456,
             input2 = 8,
@@ -81,15 +129,28 @@ function TestLShift(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run(tostring(tt.input1).." << "..tostring(tt.input2), function(t)
-            local got = bit.lshift(tt.input1, tt.input2)
+        t:Run(tostring(tt.input1) .. " << " .. tostring(tt.input2), function(t)
+            local got, err = bit.lshift(tt.input1, tt.input2)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end
 
 function TestRShift(t)
     local tests = {
+        {
+            input1 = -10,
+            input2 = 0,
+            expected = nil,
+            err = "cannot convert negative int -10 to uint32",
+        },
+        {
+            input1 = 4294967296,
+            input2 = -3,
+            expected = nil,
+            err = "int 4294967296 overflows uint32",
+        },
         {
             input1 = 123456,
             input2 = 8,
@@ -102,15 +163,26 @@ function TestRShift(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run(tostring(tt.input1).." >> "..tostring(tt.input2), function(t)
-            local got = bit.rshift(tt.input1, tt.input2)
+        t:Run(tostring(tt.input1) .. " >> " .. tostring(tt.input2), function(t)
+            local got, err = bit.rshift(tt.input1, tt.input2)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end
 
 function TestNot(t)
     local tests = {
+        {
+            input = -3,
+            expected = nil,
+            err = "cannot convert negative int -3 to uint32",
+        },
+        {
+            input = 4294967297,
+            expected = nil,
+            err = "int 4294967297 overflows uint32",
+        },
         {
             input = 65536,
             expected = 4294901759,
@@ -121,9 +193,10 @@ function TestNot(t)
         }
     }
     for _, tt in ipairs(tests) do
-        t:Run("not "..tostring(tt.input), function(t)
-            local got = bit.bnot(tt.input)
+        t:Run("not " .. tostring(tt.input), function(t)
+            local got, err = bit.bnot(tt.input)
             assert:Equal(t, tt.expected, got)
+            assert:Equal(t, tt.err, err)
         end)
     end
 end

--- a/bit/test/test_api.lua
+++ b/bit/test/test_api.lua
@@ -43,7 +43,7 @@ function TestOr(t)
             expected = nil,
             err = "cannot convert negative int -423 to uint32",
         },
-                {
+        {
             input1 = 123,
             input2 = 4294967296,
             expected = nil,

--- a/plugin/preload.go
+++ b/plugin/preload.go
@@ -4,6 +4,7 @@ import (
 	"github.com/vadv/gopher-lua-libs/argparse"
 	"github.com/vadv/gopher-lua-libs/aws/cloudwatch"
 	"github.com/vadv/gopher-lua-libs/base64"
+	"github.com/vadv/gopher-lua-libs/bit"
 	"github.com/vadv/gopher-lua-libs/cert_util"
 	"github.com/vadv/gopher-lua-libs/chef"
 	"github.com/vadv/gopher-lua-libs/cmd"
@@ -74,4 +75,5 @@ func PreloadAll(L *lua.LState) {
 	xmlpath.Preload(L)
 	yaml.Preload(L)
 	zabbix.Preload(L)
+	bit.Preload(L)
 }


### PR DESCRIPTION
Add support for bitwise operations: `and`, `or`, `xor`, `not`, `lshift`, `rshift`.