### PR TITLE
Add goos.environ() function

### DIFF
--- a/goos/README.md
+++ b/goos/README.md
@@ -26,4 +26,12 @@ if not(page_size > 0) then error("bad pagesize") end
 goos.mkdir_all("./test/test_dir/test_dir/all")
 local stat, err = goos.stat("./test/test_dir/test_dir/all")
 if err then error(err) end
+
+-- environ
+local env = goos.environ()
+print(env.PATH)  -- prints the PATH environment variable
+print(env.HOME)  -- prints the HOME environment variable
+for key, value in pairs(env) do
+    print(key .. "=" .. value)
+end
 ```

--- a/goos/api.go
+++ b/goos/api.go
@@ -3,6 +3,7 @@ package goos
 
 import (
 	"os"
+	"strings"
 
 	lua "github.com/yuin/gopher-lua"
 )
@@ -51,4 +52,16 @@ func MkdirAll(L *lua.LState) int {
 		return 1
 	}
 	return 0
+}
+
+// Environ lua goos.environ() returns table
+func Environ(L *lua.LState) int {
+	envVars := os.Environ()
+	result := L.NewTable()
+	for _, env := range envVars {
+		parts := strings.SplitN(env, "=", 2)
+		result.RawSetString(parts[0], lua.LString(parts[1]))
+	}
+	L.Push(result)
+	return 1
 }

--- a/goos/api_test.go
+++ b/goos/api_test.go
@@ -1,14 +1,19 @@
 package goos
 
 import (
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vadv/gopher-lua-libs/tests"
-	"testing"
 
 	runtime "github.com/vadv/gopher-lua-libs/runtime"
 )
 
 func TestApi(t *testing.T) {
+	os.Setenv("ENV_VAR", "TEST=1")
+	defer os.Unsetenv("ENV_VAR")
+
 	preload := tests.SeveralPreloadFuncs(
 		runtime.Preload,
 		Preload,

--- a/goos/api_test.go
+++ b/goos/api_test.go
@@ -14,6 +14,9 @@ func TestApi(t *testing.T) {
 	os.Setenv("ENV_VAR", "TEST=1")
 	defer os.Unsetenv("ENV_VAR")
 
+	os.Setenv("EMPTY_VAR", "")
+	defer os.Unsetenv("EMPTY_VAR")
+
 	preload := tests.SeveralPreloadFuncs(
 		runtime.Preload,
 		Preload,

--- a/goos/example_test.go
+++ b/goos/example_test.go
@@ -82,3 +82,27 @@ print(err == nil)
 	// Output:
 	// true
 }
+
+// goos.environ()
+func ExampleEnviron() {
+	state := lua.NewState()
+	Preload(state)
+	source := `
+local goos = require("goos")
+local env = goos.environ()
+-- Check that we get a table
+print(type(env) == "table")
+-- Check that we have at least one environment variable
+local count = 0
+for k, v in pairs(env) do
+	count = count + 1
+end
+print(count > 0)
+	`
+	if err := state.DoString(source); err != nil {
+		log.Fatal(err.Error())
+	}
+	// Output:
+	// true
+	// true
+}

--- a/goos/loader.go
+++ b/goos/loader.go
@@ -25,4 +25,5 @@ var api = map[string]lua.LGFunction{
 	"hostname":     Hostname,
 	"get_pagesize": Getpagesize,
 	"mkdir_all":    MkdirAll,
+	"environ":      Environ,
 }

--- a/goos/test/test_api.lua
+++ b/goos/test/test_api.lua
@@ -33,4 +33,6 @@ function Test_environ(t)
     assert(count > 0, "environ should return at least one environment variable")
     -- PATH should exist on most systems
     assert(env.PATH or env.Path, "PATH environment variable should exist")
+    -- Test environment variable with equals sign in value
+    assert(env.ENV_VAR == "TEST=1", "ENV_VAR should be TEST=1")
 end

--- a/goos/test/test_api.lua
+++ b/goos/test/test_api.lua
@@ -19,3 +19,18 @@ end
 function Test_pagesize(t)
     assert(goos.get_pagesize() > 0, "pagesize")
 end
+
+function Test_environ(t)
+    local env = goos.environ()
+    assert(env, "environ should return table")
+    -- Check that we get a table with environment variables
+    local count = 0
+    for k, v in pairs(env) do
+        count = count + 1
+        assert(type(k) == "string", "key should be string")
+        assert(type(v) == "string", "value should be string")
+    end
+    assert(count > 0, "environ should return at least one environment variable")
+    -- PATH should exist on most systems
+    assert(env.PATH or env.Path, "PATH environment variable should exist")
+end

--- a/goos/test/test_api.lua
+++ b/goos/test/test_api.lua
@@ -35,4 +35,6 @@ function Test_environ(t)
     assert(env.PATH or env.Path, "PATH environment variable should exist")
     -- Test environment variable with equals sign in value
     assert(env.ENV_VAR == "TEST=1", "ENV_VAR should be TEST=1")
+    -- Test environment variable with empty value
+    assert(env.EMPTY_VAR == "", "EMPTY_VAR should be empty string")
 end


### PR DESCRIPTION
Closes #73

## Changes

- Add `goos.environ()` function that returns all environment variables as a Lua table
- Add tests and documentation

## Usage

```lua
local goos = require("goos")
local env = goos.environ()
print(env.PATH)
print(env.HOME)

-- Iterate all
for key, value in pairs(env) do
    print(key .. "=" .. value)
end
```
